### PR TITLE
Fix invisible projectile and projectile destroy errors

### DIFF
--- a/Assets/Resources/Dragon Projectile.prefab
+++ b/Assets/Resources/Dragon Projectile.prefab
@@ -24,7 +24,7 @@ GameObject:
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
   m_StaticEditorFlags: 0
-  m_IsActive: 0
+  m_IsActive: 1
 --- !u!4 &2451902509671687088
 Transform:
   m_ObjectHideFlags: 0
@@ -76,8 +76,8 @@ SpriteRenderer:
   m_AutoUVMaxDistance: 0.5
   m_AutoUVMaxAngle: 89
   m_LightmapParameters: {fileID: 0}
-  m_SortingLayerID: 0
-  m_SortingLayer: 0
+  m_SortingLayerID: -79651679
+  m_SortingLayer: 2
   m_SortingOrder: 0
   m_Sprite: {fileID: 21300000, guid: a6be351f9e9dea44087316e5f3d0a368, type: 3}
   m_Color: {r: 1, g: 1, b: 1, a: 1}

--- a/Assets/Scripts/State Machine/States/Combat States/Attack States/RangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/Attack States/RangedAttackState.cs
@@ -28,7 +28,6 @@ namespace CombatStates
                 RangedProjectile.GetRotationForDirection(attackDirection)).GetComponent<RangedProjectile>();
 
             projectile.Direction = attackDirection;
-            projectile.Enable();
         }
     }
 }


### PR DESCRIPTION
The dragon's projectile was invisible because its sprite was on the wrong sorting layer and got hidden behind the background. This has been fixed.

The errors that arose when the projectile was destroyed seemed to arise from the use of `PhotonNetwork.Destroy`. This was fixed by having individual clients destroy the projectile, with only the client that spawned the projectile executing the logic to hurt any actors hit by the projectile. Bonus side effect: projectiles on other clients no longer disappear before hitting their target, since the collision detection and subsequent destruction are now local.