### PR TITLE
Update dragon enemy with melee attack ability

### DIFF
--- a/Assets/Animations/Dragon/Death_Falling.anim
+++ b/Assets/Animations/Dragon/Death_Falling.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Death_Falling
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300000, guid: 3b140706c08b7c44199957d07a6dbdcd, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: 3b140706c08b7c44199957d07a6dbdcd, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Dragon/Death_Falling.anim.meta
+++ b/Assets/Animations/Dragon/Death_Falling.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 8ec3a672dc017624f86bd4feb33f0737
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Dragon/Dragon.controller
+++ b/Assets/Animations/Dragon/Dragon.controller
@@ -367,11 +367,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 0

--- a/Assets/Animations/Dragon/Dragon.controller
+++ b/Assets/Animations/Dragon/Dragon.controller
@@ -51,11 +51,14 @@ AnimatorStateMachine:
     m_Position: {x: 30, y: 220, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -6452543390372936589}
+    m_Position: {x: 510, y: -60, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 944696802616655711}
     m_Position: {x: 280, y: -60, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 1381382083035137272}
-  - {fileID: 4325947990349573056}
+  - {fileID: 7547992536864843147}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -237,31 +240,37 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: isFalling
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: isAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDodging
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isHurt
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -275,6 +284,33 @@ AnimatorController:
     m_IKPass: 0
     m_SyncedLayerAffectsTiming: 0
     m_Controller: {fileID: 9100000}
+--- !u!1102 &944696802616655711
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Death_Falling
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 6447433649510291283}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 8ec3a672dc017624f86bd4feb33f0737, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &1381382083035137272
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -350,31 +386,6 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
---- !u!1101 &4325947990349573056
-AnimatorStateTransition:
-  m_ObjectHideFlags: 1
-  m_CorrespondingSourceObject: {fileID: 0}
-  m_PrefabInstance: {fileID: 0}
-  m_PrefabAsset: {fileID: 0}
-  m_Name: 
-  m_Conditions:
-  - m_ConditionMode: 1
-    m_ConditionEvent: isDead
-    m_EventTreshold: 0
-  m_DstStateMachine: {fileID: 0}
-  m_DstState: {fileID: -6452543390372936589}
-  m_Solo: 0
-  m_Mute: 0
-  m_IsExit: 0
-  serializedVersion: 3
-  m_TransitionDuration: 0
-  m_TransitionOffset: 0
-  m_ExitTime: 0
-  m_HasExitTime: 0
-  m_HasFixedDuration: 0
-  m_InterruptionSource: 0
-  m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 0
 --- !u!1102 &4358845319307601562
 AnimatorState:
   serializedVersion: 6
@@ -481,6 +492,34 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &6447433649510291283
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isFalling
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -6452543390372936589}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1102 &6828897138525151247
 AnimatorState:
   serializedVersion: 6
@@ -510,6 +549,31 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &7547992536864843147
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 944696802616655711}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
 --- !u!1101 &8631971896926494220
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Animations/Enemy Dragon/Attack.anim
+++ b/Assets/Animations/Enemy Dragon/Attack.anim
@@ -20,15 +20,15 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300182, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     - time: 0.071428575
-      value: {fileID: 21300176, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300184, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     - time: 0.14285715
-      value: {fileID: 21300178, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300186, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     - time: 0.21428572
-      value: {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300188, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     - time: 0.42857143
-      value: {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300188, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -48,11 +48,11 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
-    - {fileID: 21300176, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
-    - {fileID: 21300178, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
-    - {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
-    - {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300182, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300184, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300186, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300188, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300188, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/Attack.anim
+++ b/Assets/Animations/Enemy Dragon/Attack.anim
@@ -20,14 +20,20 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-    - time: 0.1
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.071428575
+      value: {fileID: 21300176, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.14285715
+      value: {fileID: 21300178, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.21428572
+      value: {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.42857143
+      value: {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 14
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -42,14 +48,17 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300176, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300178, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300180, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.11666667
+    m_StopTime: 0.5
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -69,14 +78,14 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.033333335
+  - time: 0.14285715
     functionName: ExecuteAttackEffect
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 0.083333336
+  - time: 0.35714287
     functionName: OnAttackEnd
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/Attack.anim
+++ b/Assets/Animations/Enemy Dragon/Attack.anim
@@ -21,6 +21,8 @@ AnimationClip:
   - curve:
     - time: 0
       value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - time: 0.1
+      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -41,12 +43,13 @@ AnimationClip:
       isPPtrCurve: 1
     pptrCurveMapping:
     - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.11666667
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -65,4 +68,18 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events: []
+  m_Events:
+  - time: 0.033333335
+    functionName: ExecuteAttackEffect
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0
+  - time: 0.083333336
+    functionName: OnAttackEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/Enemy Dragon/Death.anim
+++ b/Assets/Animations/Enemy Dragon/Death.anim
@@ -20,9 +20,7 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-    - time: 1
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -42,14 +40,13 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1.0166667
+    m_StopTime: 0.016666668
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -68,11 +65,4 @@ AnimationClip:
   m_EulerEditorCurves: []
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
-  m_Events:
-  - time: 0.98333335
-    functionName: OnHurtEnd
-    data: 
-    objectReferenceParameter: {fileID: 0}
-    floatParameter: 0
-    intParameter: 0
-    messageOptions: 0
+  m_Events: []

--- a/Assets/Animations/Enemy Dragon/Death.anim
+++ b/Assets/Animations/Enemy Dragon/Death.anim
@@ -20,12 +20,28 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300092, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.09090909
+      value: {fileID: 21300094, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.18181819
+      value: {fileID: 21300096, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.27272728
+      value: {fileID: 21300098, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.36363637
+      value: {fileID: 21300100, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.45454547
+      value: {fileID: 21300102, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.54545456
+      value: {fileID: 21300104, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.6363636
+      value: {fileID: 21300106, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.72727275
+      value: {fileID: 21300108, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 11
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -40,13 +56,21 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300092, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300094, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300096, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300098, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300100, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300102, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300104, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300106, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300108, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.8181819
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Enemy Dragon/Death_Falling.anim
+++ b/Assets/Animations/Enemy Dragon/Death_Falling.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Death_Falling
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300046, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Enemy Dragon/Death_Falling.anim.meta
+++ b/Assets/Animations/Enemy Dragon/Death_Falling.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: c3724bf0ce215d649932852670d609bd
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
+++ b/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
@@ -27,6 +27,34 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
+--- !u!1101 &-7013686125379458403
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isReadyingAttack
+    m_EventTreshold: 0
+  - m_ConditionMode: 2
+    m_ConditionEvent: isAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -2808131104889893101}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 1
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-6989056521051709239
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -117,6 +145,7 @@ AnimatorState:
   m_CycleOffset: 0
   m_Transitions:
   - {fileID: 6661956587460725103}
+  - {fileID: -7013686125379458403}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -200,31 +229,31 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isReadyingAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isHurt
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
+++ b/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
@@ -350,18 +350,21 @@ AnimatorStateTransition:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_Name: 
-  m_Conditions: []
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isAttacking
+    m_EventTreshold: 0
   m_DstStateMachine: {fileID: 0}
   m_DstState: {fileID: -2808131104889893101}
   m_Solo: 0
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
   m_ExitTime: 0
-  m_HasExitTime: 1
-  m_HasFixedDuration: 1
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1

--- a/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
+++ b/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
@@ -125,11 +125,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 0

--- a/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
+++ b/Assets/Animations/Enemy Dragon/Dragon Enemy.controller
@@ -80,6 +80,34 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-3237363906969328500
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isFalling
+    m_EventTreshold: 0
+  - m_ConditionMode: 1
+    m_ConditionEvent: isDead
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 5330945866474991862}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 0
 --- !u!1102 &-2808131104889893101
 AnimatorState:
   serializedVersion: 6
@@ -108,7 +136,7 @@ AnimatorState:
   m_MirrorParameter: 
   m_CycleOffsetParameter: 
   m_TimeParameter: 
---- !u!1101 &-2368943109938510451
+--- !u!1101 &-2642845712106476975
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
   m_CorrespondingSourceObject: {fileID: 0}
@@ -116,6 +144,9 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isFalling
+    m_EventTreshold: 0
   - m_ConditionMode: 1
     m_ConditionEvent: isDead
     m_EventTreshold: 0
@@ -132,7 +163,7 @@ AnimatorStateTransition:
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
-  m_CanTransitionToSelf: 0
+  m_CanTransitionToSelf: 1
 --- !u!1102 &-1872974550438420593
 AnimatorState:
   serializedVersion: 6
@@ -229,31 +260,37 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
+  - m_Name: isFalling
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   - m_Name: isReadyingAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isHurt
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 9100000}
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -419,11 +456,14 @@ AnimatorStateMachine:
     m_Position: {x: 260, y: 10, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 611551883063859251}
-    m_Position: {x: 260, y: -60, z: 0}
+    m_Position: {x: 510, y: -90, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 5330945866474991862}
+    m_Position: {x: 260, y: -90, z: 0}
   m_ChildStateMachines: []
   m_AnyStateTransitions:
   - {fileID: 298828759728001018}
-  - {fileID: -2368943109938510451}
+  - {fileID: -3237363906969328500}
   m_EntryTransitions: []
   m_StateMachineTransitions: {}
   m_StateMachineBehaviours: []
@@ -457,6 +497,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &5330945866474991862
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Death_Falling
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -2642845712106476975}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: c3724bf0ce215d649932852670d609bd, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &6661956587460725103
 AnimatorStateTransition:
   m_ObjectHideFlags: 1

--- a/Assets/Animations/Enemy Dragon/Flying.anim
+++ b/Assets/Animations/Enemy Dragon/Flying.anim
@@ -20,7 +20,7 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -40,7 +40,7 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/Hurt.anim
+++ b/Assets/Animations/Enemy Dragon/Hurt.anim
@@ -20,9 +20,9 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300040, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     - time: 1
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -42,8 +42,8 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300040, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/Idle.anim
+++ b/Assets/Animations/Enemy Dragon/Idle.anim
@@ -20,7 +20,7 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -40,7 +40,7 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/ReadyAttack.anim
+++ b/Assets/Animations/Enemy Dragon/ReadyAttack.anim
@@ -20,7 +20,7 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+      value: {fileID: 21300182, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -40,7 +40,7 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300182, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Dragon/ReadyAttack.anim
+++ b/Assets/Animations/Enemy Dragon/ReadyAttack.anim
@@ -20,7 +20,7 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+      value: {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
@@ -40,7 +40,7 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
+    - {fileID: 21300174, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}

--- a/Assets/Animations/Enemy Knight/Knight Enemy.controller
+++ b/Assets/Animations/Enemy Knight/Knight Enemy.controller
@@ -146,11 +146,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.25
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75
+  m_ExitTime: 0
   m_HasExitTime: 0
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 0
@@ -379,49 +379,49 @@ AnimatorController:
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isJumping
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isFalling
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isReadyingAttack
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isAttacking
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isStunned
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isHurt
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   - m_Name: isDead
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
     m_DefaultBool: 0
-    m_Controller: {fileID: 0}
+    m_Controller: {fileID: 9100000}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer

--- a/Assets/Animations/Knight/Knight.controller
+++ b/Assets/Animations/Knight/Knight.controller
@@ -672,11 +672,11 @@ AnimatorStateTransition:
   m_Mute: 0
   m_IsExit: 0
   serializedVersion: 3
-  m_TransitionDuration: 0.24999988
+  m_TransitionDuration: 0
   m_TransitionOffset: 0
-  m_ExitTime: 0.75000006
+  m_ExitTime: 0
   m_HasExitTime: 0
-  m_HasFixedDuration: 1
+  m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 0

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -9,9 +9,9 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 6084731882482450353}
-  - component: {fileID: 3625236102993533556}
+  - component: {fileID: 5886154097904693633}
   - component: {fileID: 8923394087307039422}
-  m_Layer: 10
+  m_Layer: 0
   m_Name: Wall Collision Detector
   m_TagString: Untagged
   m_Icon: {fileID: 0}
@@ -32,8 +32,8 @@ Transform:
   m_Father: {fileID: 6640825776839569102}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &3625236102993533556
-CircleCollider2D:
+--- !u!61 &5886154097904693633
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -45,9 +45,19 @@ CircleCollider2D:
   m_IsTrigger: 1
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.035, y: -0.53}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 3.125, y: 2.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
-  m_Radius: 0.29
+  m_Size: {x: 0.68, y: 1.32}
+  m_EdgeRadius: 0
 --- !u!114 &8923394087307039422
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -72,7 +82,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8741898079270909711}
-  - component: {fileID: 5117750422463035635}
+  - component: {fileID: 6758016192082639341}
   m_Layer: 10
   m_Name: Collider
   m_TagString: Untagged
@@ -94,8 +104,8 @@ Transform:
   m_Father: {fileID: 6640825776839569102}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
---- !u!58 &5117750422463035635
-CircleCollider2D:
+--- !u!61 &6758016192082639341
+BoxCollider2D:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
@@ -107,9 +117,19 @@ CircleCollider2D:
   m_IsTrigger: 0
   m_UsedByEffector: 0
   m_UsedByComposite: 0
-  m_Offset: {x: 0, y: 0}
+  m_Offset: {x: 0.035, y: -0.53}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0.5, y: 0.5}
+    oldSize: {x: 3.125, y: 2.5}
+    newSize: {x: 1, y: 1}
+    adaptiveTilingThreshold: 0.5
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
   serializedVersion: 2
-  m_Radius: 0.27
+  m_Size: {x: 0.68, y: 1.32}
+  m_EdgeRadius: 0
 --- !u!1 &4323829788290658441
 GameObject:
   m_ObjectHideFlags: 0
@@ -242,12 +262,12 @@ SpriteRenderer:
   m_SortingLayerID: -79651679
   m_SortingLayer: 2
   m_SortingOrder: 1
-  m_Sprite: {fileID: 21300000, guid: dff013c39a5dd9141b8f889d165e70ba, type: 3}
-  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_Sprite: {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+  m_Color: {r: 0.8717336, g: 0.21933962, b: 0.8773585, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 3.125, y: 2.5}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -119,6 +119,7 @@ GameObject:
   serializedVersion: 6
   m_Component:
   - component: {fileID: 8957541770380697155}
+  - component: {fileID: 458767237906566525}
   m_Layer: 10
   m_Name: Combat Abilities
   m_TagString: Untagged
@@ -138,8 +139,23 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6640825776839569102}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &458767237906566525
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4323829788290658441}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 3b8670ec07ee8a6449503ea24e6068fb, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  isReadyRequired: 1
+  readyDuration: 2
+  attackEffectArea: {fileID: 7280965100743785369}
 --- !u!1 &6640825776839569100
 GameObject:
   m_ObjectHideFlags: 0
@@ -181,6 +197,7 @@ Transform:
   m_Children:
   - {fileID: 8741898079270909711}
   - {fileID: 6084731882482450353}
+  - {fileID: 1302218856726869186}
   - {fileID: 8957541770380697155}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -309,6 +326,7 @@ MonoBehaviour:
   rigidbody2d: {fileID: 6640825776839569096}
   animator: {fileID: 6640825776839569097}
   isDefaultFacingRight: 0
+  defaultStoppingDistanceFromNavTargets: 1.4
   movementSpeed: 4
 --- !u!114 &7213589635427211298
 MonoBehaviour:
@@ -327,7 +345,9 @@ MonoBehaviour:
   attackEffectLayer:
     serializedVersion: 2
     m_Bits: 256
-  combatAbilities: []
+  combatAbilities:
+  - abilityIdentifier: 0
+    ability: {fileID: 458767237906566525}
   health: {fileID: 5584288266804474021}
   wallCollisionDetector: {fileID: 8923394087307039422}
   knockbackSpeed: 0
@@ -471,3 +491,48 @@ MonoBehaviour:
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0
+--- !u!1 &7715578728906320938
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1302218856726869186}
+  - component: {fileID: 7280965100743785369}
+  m_Layer: 0
+  m_Name: Attack Effect Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &1302218856726869186
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7715578728906320938}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.767, y: -0.421, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6640825776839569102}
+  m_RootOrder: 2
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &7280965100743785369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7715578728906320938}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 84f2a5283f197bc418a8b8f5be7b7904, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  size: {x: 1.4, y: 0.6}
+  drawAreas: 1

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -30,7 +30,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6640825776839569102}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!61 &5886154097904693633
 BoxCollider2D:
@@ -159,7 +159,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6640825776839569102}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &458767237906566525
 MonoBehaviour:
@@ -216,6 +216,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 8741898079270909711}
+  - {fileID: 8984497115648075684}
   - {fileID: 6084731882482450353}
   - {fileID: 1302218856726869186}
   - {fileID: 8957541770380697155}
@@ -345,9 +346,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rigidbody2d: {fileID: 6640825776839569096}
   animator: {fileID: 6640825776839569097}
+  groundDetector: {fileID: 791881558941451881}
   isDefaultFacingRight: 0
-  defaultStoppingDistanceFromNavTargets: 1.4
+  defaultStoppingDistanceFromNavTargets: 0.91
   movementSpeed: 4
+  canLandOnGround: 0
 --- !u!114 &7213589635427211298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -508,6 +511,9 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 2
     Name: isDead
+  - Type: 4
+    SynchronizeType: 2
+    Name: isFalling
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0
@@ -540,7 +546,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6640825776839569102}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7280965100743785369
 MonoBehaviour:
@@ -556,3 +562,76 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   size: {x: 0.72, y: 1.32}
   drawAreas: 1
+--- !u!1 &9211207551564226715
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8984497115648075684}
+  - component: {fileID: 1042383563599664761}
+  - component: {fileID: 791881558941451881}
+  m_Layer: 0
+  m_Name: GroundDetector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8984497115648075684
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9211207551564226715}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.015, y: -1.184, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6640825776839569102}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1042383563599664761
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9211207551564226715}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.53, y: 0.05}
+  m_EdgeRadius: 0
+--- !u!114 &791881558941451881
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 9211207551564226715}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 432aae23ff4524e458902c3b8c6b3eee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  surfacesLayerMask:
+    serializedVersion: 2
+    m_Bits: 64

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -536,7 +536,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7715578728906320938}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.767, y: -0.421, z: 0}
+  m_LocalPosition: {x: 0.557, y: 0.054, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 6640825776839569102}
@@ -554,5 +554,5 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 84f2a5283f197bc418a8b8f5be7b7904, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  size: {x: 1.4, y: 0.6}
+  size: {x: 0.72, y: 1.32}
   drawAreas: 1

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -246,7 +246,7 @@ MonoBehaviour:
   rigidbody2d: {fileID: 4470413134207635895}
   animator: {fileID: 3533750638843532997}
   isDefaultFacingRight: 1
-  defaultStoppingDistanceFromNavTargets: 2.1
+  defaultStoppingDistanceFromNavTargets: 1.6
   movementSpeed: 6
 --- !u!114 &3483110514655366300
 MonoBehaviour:

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -87,8 +87,9 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 718891108291270556}
-  - {fileID: 8972197996417656447}
+  - {fileID: 5960651057919622052}
   - {fileID: 6446324908195120128}
+  - {fileID: 8972197996417656447}
   - {fileID: 614414376297081873}
   m_Father: {fileID: 0}
   m_RootOrder: 0
@@ -245,9 +246,11 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rigidbody2d: {fileID: 4470413134207635895}
   animator: {fileID: 3533750638843532997}
+  groundDetector: {fileID: 6523712521498633943}
   isDefaultFacingRight: 1
   defaultStoppingDistanceFromNavTargets: 1.6
   movementSpeed: 6
+  canLandOnGround: 0
 --- !u!114 &3483110514655366300
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -397,6 +400,9 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 2
     Name: isDead
+  - Type: 4
+    SynchronizeType: 2
+    Name: isFalling
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0
@@ -493,7 +499,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4470413134207635894}
-  m_RootOrder: 3
+  m_RootOrder: 4
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &5976937371193107433
 MonoBehaviour:
@@ -523,6 +529,79 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   speed: 20
   distance: 4
+--- !u!1 &8714695237697900579
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 5960651057919622052}
+  - component: {fileID: 1683631935823656979}
+  - component: {fileID: 6523712521498633943}
+  m_Layer: 0
+  m_Name: Ground Detector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &5960651057919622052
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8714695237697900579}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.164, y: -0.319, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4470413134207635894}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &1683631935823656979
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8714695237697900579}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 0.86, y: 0.05}
+  m_EdgeRadius: 0
+--- !u!114 &6523712521498633943
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8714695237697900579}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 432aae23ff4524e458902c3b8c6b3eee, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  surfacesLayerMask:
+    serializedVersion: 2
+    m_Bits: 64
 --- !u!1 &9179954432882551474
 GameObject:
   m_ObjectHideFlags: 0
@@ -551,5 +630,5 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4470413134207635894}
-  m_RootOrder: 1
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -246,6 +246,7 @@ MonoBehaviour:
   rigidbody2d: {fileID: 4470413134207635895}
   animator: {fileID: 3533750638843532997}
   isDefaultFacingRight: 1
+  defaultStoppingDistanceFromNavTargets: 2.1
   movementSpeed: 6
 --- !u!114 &3483110514655366300
 MonoBehaviour:
@@ -410,7 +411,7 @@ GameObject:
   - component: {fileID: 6446324908195120128}
   - component: {fileID: 3901688964061665601}
   - component: {fileID: 7163776362713714178}
-  m_Layer: 8
+  m_Layer: 0
   m_Name: Wall Collision Detector
   m_TagString: Untagged
   m_Icon: {fileID: 0}

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -195,7 +195,7 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 3.125, y: 2.5}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -274,6 +274,7 @@ MonoBehaviour:
   rigidbody2d: {fileID: 5693331145748344916}
   animator: {fileID: 5693331145748344918}
   isDefaultFacingRight: 0
+  defaultStoppingDistanceFromNavTargets: 1.4
   groundDetector: {fileID: 5693331146666542379}
   horizontalMoveSpeed: 8
   jumpForce: 12

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -273,9 +273,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rigidbody2d: {fileID: 5693331145748344916}
   animator: {fileID: 5693331145748344918}
+  groundDetector: {fileID: 5693331146666542379}
   isDefaultFacingRight: 0
   defaultStoppingDistanceFromNavTargets: 1.4
-  groundDetector: {fileID: 5693331146666542379}
   horizontalMoveSpeed: 8
   jumpForce: 12
 --- !u!114 &7568959259614269199

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -343,7 +343,7 @@ SpriteRenderer:
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
-  m_Size: {x: 1, y: 1}
+  m_Size: {x: 3.125, y: 2.5}
   m_AdaptiveModeThreshold: 0.5
   m_SpriteTileMode: 0
   m_WasSpriteAssigned: 1

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -491,6 +491,7 @@ MonoBehaviour:
   rigidbody2d: {fileID: 5696632616774609753}
   animator: {fileID: 6393426157099837368}
   isDefaultFacingRight: 1
+  defaultStoppingDistanceFromNavTargets: 1.4
   groundDetector: {fileID: 2344377606277045393}
   horizontalMoveSpeed: 8
   jumpForce: 12

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -490,9 +490,9 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   rigidbody2d: {fileID: 5696632616774609753}
   animator: {fileID: 6393426157099837368}
+  groundDetector: {fileID: 2344377606277045393}
   isDefaultFacingRight: 1
   defaultStoppingDistanceFromNavTargets: 1.4
-  groundDetector: {fileID: 2344377606277045393}
   horizontalMoveSpeed: 8
   jumpForce: 12
 --- !u!114 &4584270387848782332

--- a/Assets/Scripts/AI Behavior Tree/BehaviorTree.cs
+++ b/Assets/Scripts/AI Behavior Tree/BehaviorTree.cs
@@ -17,19 +17,15 @@ namespace AiBehaviorTrees
         private BehaviorNode entry;
         private BehaviorNode update;
 
-        public Function TreeFunction { get; private set; }
-
-        public BehaviorTree(Function function, BehaviorNode update)
+        public BehaviorTree(BehaviorNode update)
         {
-            TreeFunction = function;
             this.update = update;
 
             Blackboard.CreateBlackboardForTree(update);
         }
 
-        public BehaviorTree(Function function, BehaviorNode entry, BehaviorNode update)
+        public BehaviorTree(BehaviorNode entry, BehaviorNode update)
         {
-            TreeFunction = function;
             this.entry = entry;
             this.update = update;
 

--- a/Assets/Scripts/AI Behavior Tree/Blackboard/GeneralBlackboardKeys.cs
+++ b/Assets/Scripts/AI Behavior Tree/Blackboard/GeneralBlackboardKeys.cs
@@ -2,6 +2,7 @@ namespace AiBehaviorTreeBlackboards
 {
     public static class GeneralBlackboardKeys
     {
-        public static readonly string NAV_TARGET = "NavigationTarget";
+        public static readonly string NAV_TARGET = "navigationTarget";
+        public static readonly string NAV_TARGET_STOPPING_DISTANCE = "navigationTargetStoppingDistance";
     }
 }

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GetVisibleCombatTargetNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GetVisibleCombatTargetNode.cs
@@ -37,7 +37,7 @@ namespace AiBehaviorTreeNodes
                 return NodeState.FAILURE;
             }
 
-            Blackboard.SetData(CombatBlackboardKeys.COMBAT_TARGET, targetActor.gameObject);
+            Blackboard.SetData(CombatBlackboardKeys.COMBAT_TARGET, targetActor);
             return NodeState.SUCCESS;
         }
     }

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GoToNavTargetNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GoToNavTargetNode.cs
@@ -35,7 +35,7 @@ namespace AiBehaviorTreeNodes
             Vector2 navTargetPos = (Vector2)Blackboard.GetData(GeneralBlackboardKeys.NAV_TARGET);
             Vector2 currentPos = ownerMovement.transform.position;
 
-            float distanceToTarget = Mathf.Abs(currentPos.x - navTargetPos.x);
+            float distanceToTarget = Vector2.Distance(currentPos, navTargetPos);
             if (useStoppingDistance && distanceToTarget <= (float)Blackboard.GetData(GeneralBlackboardKeys.NAV_TARGET_STOPPING_DISTANCE)
                 || !useStoppingDistance && distanceToTarget <= 0.01f)
             {

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GoToNavTargetNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/GoToNavTargetNode.cs
@@ -36,7 +36,7 @@ namespace AiBehaviorTreeNodes
             Vector2 currentPos = ownerMovement.transform.position;
 
             float distanceToTarget = Mathf.Abs(currentPos.x - navTargetPos.x);
-            if (useStoppingDistance && distanceToTarget <= ownerMovement.GetStoppingDistanceFromNavTarget()
+            if (useStoppingDistance && distanceToTarget <= (float)Blackboard.GetData(GeneralBlackboardKeys.NAV_TARGET_STOPPING_DISTANCE)
                 || !useStoppingDistance && distanceToTarget <= 0.01f)
             {
                 return NodeState.SUCCESS;

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/IsCombatTargetInRangeNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/IsCombatTargetInRangeNode.cs
@@ -8,18 +8,16 @@ namespace AiBehaviorTreeNodes
     public class IsCombatTargetInRangeNode : BehaviorNode
     {
         private readonly Transform ownerTransform;
-        private readonly Movement ownerMovement;
         
         public IsCombatTargetInRangeNode(Movement ownerMovement)
         {
             ownerTransform = ownerMovement.transform;
-            this.ownerMovement = ownerMovement;
         }
 
         public override NodeState Execute()
         {
-            Vector2 targetPosition = ((GameObject)Blackboard.GetData(CombatBlackboardKeys.COMBAT_TARGET)).transform.position;
-            return Vector2.Distance(ownerTransform.position, targetPosition) <= ownerMovement.GetStoppingDistanceFromNavTarget()
+            Vector2 targetPosition = ((ActorController)Blackboard.GetData(CombatBlackboardKeys.COMBAT_TARGET)).transform.position;
+            return Vector2.Distance(ownerTransform.position, targetPosition) <= (float)Blackboard.GetData(GeneralBlackboardKeys.NAV_TARGET_STOPPING_DISTANCE)
                 ? NodeState.SUCCESS
                 : NodeState.FAILURE;
         }

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/SetCombatTargetPosNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/SetCombatTargetPosNode.cs
@@ -15,10 +15,21 @@ namespace AiBehaviorTreeNodes
     /// </remarks>
     public class SetCombatTargetPosNode : BehaviorNode
     {
+        private readonly Movement ownerMovement;
+
+        public SetCombatTargetPosNode(Movement ownerMovement)
+        {
+            this.ownerMovement = ownerMovement;
+        }
+
         public override NodeState Execute()
         {
-            GameObject target = (GameObject)Blackboard.GetData(CombatBlackboardKeys.COMBAT_TARGET);
+            ActorController target = (ActorController)Blackboard.GetData(CombatBlackboardKeys.COMBAT_TARGET);
             Blackboard.SetData(GeneralBlackboardKeys.NAV_TARGET, (Vector2)target.transform.position);
+            Blackboard.SetData(
+                GeneralBlackboardKeys.NAV_TARGET_STOPPING_DISTANCE,
+                Mathf.Max(ownerMovement.DefaultStoppingDistanceFromNavTargets, target.Movement.DefaultStoppingDistanceFromNavTargets));
+
             return NodeState.SUCCESS;
         }
     }

--- a/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/SetCombatTargetPosNode.cs
+++ b/Assets/Scripts/AI Behavior Tree/Nodes/Action Nodes/SetCombatTargetPosNode.cs
@@ -28,7 +28,7 @@ namespace AiBehaviorTreeNodes
             Blackboard.SetData(GeneralBlackboardKeys.NAV_TARGET, (Vector2)target.transform.position);
             Blackboard.SetData(
                 GeneralBlackboardKeys.NAV_TARGET_STOPPING_DISTANCE,
-                Mathf.Max(ownerMovement.DefaultStoppingDistanceFromNavTargets, target.Movement.DefaultStoppingDistanceFromNavTargets));
+                Mathf.Min(ownerMovement.DefaultStoppingDistanceFromNavTargets, target.Movement.DefaultStoppingDistanceFromNavTargets));
 
             return NodeState.SUCCESS;
         }

--- a/Assets/Scripts/AI Behavior Tree/Tree Constructors/CombatTreeConstructor.cs
+++ b/Assets/Scripts/AI Behavior Tree/Tree Constructors/CombatTreeConstructor.cs
@@ -11,7 +11,6 @@ namespace AiBehaviorTrees
         public static BehaviorTree ConstructGroundCombatTree(Movement movement, Combat combat)
         {
             return new BehaviorTree(
-                BehaviorTree.Function.COMBAT,
                 new SequenceNode(new List<BehaviorNode>()
                 {
                     new GetVisibleCombatTargetNode(combat),
@@ -46,7 +45,6 @@ namespace AiBehaviorTrees
         public static BehaviorTree ConstructAirCombatTree(Movement movement, Combat combat)
         {
             return new BehaviorTree(
-                BehaviorTree.Function.COMBAT,
                 new SequenceNode(new List<BehaviorNode>()
                 {
                     new GetVisibleCombatTargetNode(combat),

--- a/Assets/Scripts/AI Behavior Tree/Tree Constructors/CombatTreeConstructor.cs
+++ b/Assets/Scripts/AI Behavior Tree/Tree Constructors/CombatTreeConstructor.cs
@@ -8,7 +8,7 @@ namespace AiBehaviorTrees
 {
     public static class CombatTreeConstructor
     {
-        public static BehaviorTree ConstructGroundCombatTree(Movement movement, Combat combat)
+        public static BehaviorTree ConstructMeleeCombatTree(Movement movement, Combat combat)
         {
             return new BehaviorTree(
                 new SequenceNode(new List<BehaviorNode>()
@@ -32,47 +32,11 @@ namespace AiBehaviorTrees
                         // chasing target
                         new SequenceNode(new List<BehaviorNode>()
                         {
-                            new SetCombatTargetPosNode(),
+                            new SetCombatTargetPosNode(movement),
                             new GoToNavTargetNode(movement, true),
                             new StopMovingNode(movement),
                             new FaceNavTargetNode(movement),
                             new StartMeleeAttackNode(combat)
-                        })
-                    })
-                }));
-        }
-
-        public static BehaviorTree ConstructAirCombatTree(Movement movement, Combat combat)
-        {
-            return new BehaviorTree(
-                new SequenceNode(new List<BehaviorNode>()
-                {
-                    new GetVisibleCombatTargetNode(combat),
-                    new SelectorNode(new List<BehaviorNode>()
-                    {
-                        // in combat state, engaging target
-                        new SequenceNode(new List<BehaviorNode>()
-                        {
-                            new SetCombatTargetPosNode(),
-                            new SequenceNode(new List<BehaviorNode>()
-                            {
-                                // in ready-attack state
-                                new IsStateMachineInStateNode(combat.CombatStateMachine, typeof(ReadyAttackState)),
-                                new SelectorNode(new List<BehaviorNode>()
-                                {
-                                    // turn to face combat target if charge direction not yet locked
-                                    new HasLockedTargetPositionNode(combat),
-                                    new FaceNavTargetNode(movement)
-                                })
-                            })
-                        }),
-                        new IsStateMachineInStateNode(combat.CombatStateMachine, typeof(CombatState)),
-                        // chasing target
-                        new SequenceNode(new List<BehaviorNode>()
-                        {
-                            new SetCombatTargetPosNode(),
-                            new GoToNavTargetNode(movement, false),
-                            new StopMovingNode(movement)
                         })
                     })
                 }));

--- a/Assets/Scripts/Actor Components/Movement/AirMovement.cs
+++ b/Assets/Scripts/Actor Components/Movement/AirMovement.cs
@@ -51,6 +51,9 @@ public class AirMovement : Movement
     public void ToggleGravity(bool isEnabled)
     {
         rigidbody2d.gravityScale = isEnabled ? 5f : 0f;
-        MovementStateMachine.ChangeState(new FallingState(this));
+        if (isEnabled)
+        {
+            MovementStateMachine.ChangeState(new FallingState(this));
+        }
     }
 }

--- a/Assets/Scripts/Actor Components/Movement/AirMovement.cs
+++ b/Assets/Scripts/Actor Components/Movement/AirMovement.cs
@@ -7,10 +7,12 @@ using AirMovementStates;
 public class AirMovement : Movement
 {
     [SerializeField] private float movementSpeed;
+    [SerializeField] private bool canLandOnGround;
 
     private AirMovementStateMachine movementStateMachine;
 
     public float MovementSpeed { get => movementSpeed; }
+    public bool CanLandOnGround { get => canLandOnGround; set => canLandOnGround = value; }
 
     public override MovementStateMachine MovementStateMachine { get => movementStateMachine; }
 
@@ -46,21 +48,9 @@ public class AirMovement : Movement
         }
     }
 
-    public void UpdateHorizontalMovement(float direction)
+    public void ToggleGravity(bool isEnabled)
     {
-        CachedMovementDirection = new Vector2(direction, CachedMovementDirection.y);
-        if (MovementStateMachine.CurrState is AirborneState airborneState)
-        {
-            airborneState.UpdateHorizontalMovement(direction);
-        }
-    }
-
-    public void UpdateVerticalMovement(float direction)
-    {
-        CachedMovementDirection = new Vector2(CachedMovementDirection.x, direction);
-        if (MovementStateMachine.CurrState is AirborneState airborneState)
-        {
-            airborneState.UpdateVerticalMovement(direction);
-        }
+        rigidbody2d.gravityScale = isEnabled ? 5f : 0f;
+        MovementStateMachine.ChangeState(new FallingState(this));
     }
 }

--- a/Assets/Scripts/Actor Components/Movement/GroundMovement.cs
+++ b/Assets/Scripts/Actor Components/Movement/GroundMovement.cs
@@ -6,13 +6,11 @@ using GroundMovementStates;
 
 public class GroundMovement : Movement
 {
-    [SerializeField] protected SurfaceDetector groundDetector;
     [SerializeField] private float horizontalMoveSpeed;
     [SerializeField] private float jumpForce;
 
     private GroundMovementStateMachine movementStateMachine;
 
-    public SurfaceDetector GroundDetector { get => groundDetector; }
     public float HorizontalMoveSpeed { get => horizontalMoveSpeed; }
     public float JumpForce { get => jumpForce; }
 

--- a/Assets/Scripts/Actor Components/Movement/Movement.cs
+++ b/Assets/Scripts/Actor Components/Movement/Movement.cs
@@ -9,11 +9,13 @@ public abstract class Movement : MonoBehaviour
 
     [SerializeField] protected Rigidbody2D rigidbody2d;
     [SerializeField] protected Animator animator;
+    [SerializeField] protected SurfaceDetector groundDetector;
     [SerializeField] private bool isDefaultFacingRight = true;
     [SerializeField] private float defaultStoppingDistanceFromNavTargets;
 
     public Rigidbody2D Rigidbody2d { get => rigidbody2d; }
     public Animator Animator { get => animator; }
+    public SurfaceDetector GroundDetector { get => groundDetector; }
     public float DefaultStoppingDistanceFromNavTargets { get => defaultStoppingDistanceFromNavTargets; }
 
     public bool IsFacingRight { get; private set; }

--- a/Assets/Scripts/Actor Components/Movement/Movement.cs
+++ b/Assets/Scripts/Actor Components/Movement/Movement.cs
@@ -10,9 +10,11 @@ public abstract class Movement : MonoBehaviour
     [SerializeField] protected Rigidbody2D rigidbody2d;
     [SerializeField] protected Animator animator;
     [SerializeField] private bool isDefaultFacingRight = true;
+    [SerializeField] private float defaultStoppingDistanceFromNavTargets;
 
     public Rigidbody2D Rigidbody2d { get => rigidbody2d; }
     public Animator Animator { get => animator; }
+    public float DefaultStoppingDistanceFromNavTargets { get => defaultStoppingDistanceFromNavTargets; }
 
     public bool IsFacingRight { get; private set; }
     public Vector2 CachedMovementDirection { get; protected set; }
@@ -60,11 +62,5 @@ public abstract class Movement : MonoBehaviour
                     $"{System.Enum.GetName(typeof(Direction), toDirection)} " +
                     "is not a valid direction to flip towards");
         }
-    }
-
-    public float GetStoppingDistanceFromNavTarget()
-    {
-        // TODO: make this value a serialized field once we're sure no one else is modifying prefabs
-        return 1.4f;
     }
 }

--- a/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
+++ b/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
@@ -16,7 +16,7 @@ public class DragonEnemyController : EnemyController
             {
                 // construct behavior trees
                 {
-                    BehaviorTree.Function.COMBAT, CombatTreeConstructor.ConstructAirCombatTree(movement, combat)
+                    BehaviorTree.Function.COMBAT, CombatTreeConstructor.ConstructMeleeCombatTree(movement, combat)
                 }
             },
             BehaviorTree.Function.COMBAT);

--- a/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
+++ b/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
@@ -25,6 +25,7 @@ public class DragonEnemyController : EnemyController
     protected override void HandleDeathEvent()
     {
         base.HandleDeathEvent();
-        movement.Rigidbody2d.gravityScale = 5;
+        movement.CanLandOnGround = true;
+        movement.ToggleGravity(true);
     }
 }

--- a/Assets/Scripts/Actor Controllers/KnightEnemyController.cs
+++ b/Assets/Scripts/Actor Controllers/KnightEnemyController.cs
@@ -16,7 +16,7 @@ public class KnightEnemyController : EnemyController
             {
                 // construct behavior trees
                 {
-                    BehaviorTree.Function.COMBAT, CombatTreeConstructor.ConstructGroundCombatTree(movement, combat)
+                    BehaviorTree.Function.COMBAT, CombatTreeConstructor.ConstructMeleeCombatTree(movement, combat)
                 }
             },
             BehaviorTree.Function.COMBAT);

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -108,6 +108,7 @@ public class DragonPlayerController : PlayerController
     }
     protected void HandleDeathEvent()
     {
-        movement.Rigidbody2d.gravityScale = 5;
+        movement.CanLandOnGround = true;
+        movement.ToggleGravity(true);
     }
 }

--- a/Assets/Scripts/State Machine/State Machines/Movement State Machines/AirMovementStateMachine.cs
+++ b/Assets/Scripts/State Machine/State Machines/Movement State Machines/AirMovementStateMachine.cs
@@ -9,7 +9,9 @@ namespace StateMachines
     {
         public AirMovementStateMachine()
         {
-            transitions[typeof(AirborneState)] = new HashSet<System.Type>();
+            transitions[typeof(AirborneState)] = new HashSet<System.Type>() { typeof(FallingState), typeof(GroundedState) };
+            transitions[typeof(FallingState)] = new HashSet<System.Type>() { typeof(GroundedState) };
+            transitions[typeof(GroundedState)] = new HashSet<System.Type>();
         }
     }
 }

--- a/Assets/Scripts/State Machine/States/Air Movement States/FallingState.cs
+++ b/Assets/Scripts/State Machine/States/Air Movement States/FallingState.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AirMovementStates
+{
+    public class FallingState : AirMovementState
+    {
+        public FallingState(AirMovement owner) : base(owner) { }
+
+        public override void Enter()
+        {
+            owner.Animator.SetBool("isFalling", true);
+        }
+
+        public override void Execute()
+        {
+            if (owner.GroundDetector.IsInContact)
+            {
+                owner.MovementStateMachine.ChangeState(new GroundedState(owner));
+            }
+        }
+
+        public override void Exit()
+        {
+            owner.Animator.SetBool("isFalling", false);
+        }
+    }
+}

--- a/Assets/Scripts/State Machine/States/Air Movement States/FallingState.cs.meta
+++ b/Assets/Scripts/State Machine/States/Air Movement States/FallingState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 26839a5d5dd9ca9448e2ec951bd1e403
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/State Machine/States/Air Movement States/GroundedState.cs
+++ b/Assets/Scripts/State Machine/States/Air Movement States/GroundedState.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace AirMovementStates
+{
+    public class GroundedState : AirMovementState
+    {
+        public GroundedState(AirMovement owner) : base(owner) { }
+
+        public override void Enter()
+        {
+
+        }
+
+        public override void Execute()
+        {
+
+        }
+
+        public override void Exit()
+        {
+
+        }
+    }
+}

--- a/Assets/Scripts/State Machine/States/Air Movement States/GroundedState.cs.meta
+++ b/Assets/Scripts/State Machine/States/Air Movement States/GroundedState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4c2d0e0e0c2057e4e8649110dd873d45
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
@@ -21,7 +21,7 @@ namespace CombatStates
 
         public override void Exit()
         {
-            
+            owner.Animator.SetBool("isDead", false);
         }
     }
 }

--- a/ProjectSettings/Physics2DSettings.asset
+++ b/ProjectSettings/Physics2DSettings.asset
@@ -53,4 +53,4 @@ Physics2DSettings:
   m_ColliderAsleepColor: {r: 0.5686275, g: 0.95686275, b: 0.54509807, a: 0.36078432}
   m_ColliderContactColor: {r: 1, g: 0, b: 1, a: 0.6862745}
   m_ColliderAABBColor: {r: 1, g: 1, b: 0, a: 0.2509804}
-  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffff7ff8ffff7ffcffff7ff8ffff7ff9ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff
+  m_LayerCollisionMatrix: ffffffffffffffffffffffffffffffffffffffffffffffffffffffff7ff8ffff7ff8ffff7ff8ffff7ff8ffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff


### PR DESCRIPTION
Prefabs modified: Dragon, Dragon Enemy, Knight, Knight Enemy

Implemented
- Dragon enemy has been updated with a melee attack; it will move to the dragon and ready its attack for 2 seconds before attacking
- Dragon enemy sprites have been updated with prototype hero sprites (colored pink)
- Extend feature where aerial actors fall out of the sky
  - When gravity is toggled on, they enter a new `FallingState` with an appropriate animation
  - Upon reaching the ground while falling, they enter a new `GroundedState` in the `AirMovementStates` namespace
  - Currently only used so that the dragon enemy can have an animation that plays when crashing to the ground after dying (applies to dragon as well but with placeholder animation), but could be a good base for allowing the dragon to land on the ground if we ever decide to do that in the far far future