### PR TITLE
Add text to level select to reflect player's role choice

### DIFF
--- a/Assets/Scenes/LevelSelect.unity
+++ b/Assets/Scenes/LevelSelect.unity
@@ -138,6 +138,10 @@ PrefabInstance:
       propertyPath: levelNumber
       value: 1
       objectReference: {fileID: 0}
+    - target: {fileID: 5335147494950935744, guid: 1d428997838859f49867c1e16c0eee47, type: 3}
+      propertyPath: m_IsActive
+      value: 0
+      objectReference: {fileID: 0}
     - target: {fileID: 5335147495110332099, guid: 1d428997838859f49867c1e16c0eee47, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
       value: 1
@@ -256,6 +260,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5335147495110332157, guid: 1d428997838859f49867c1e16c0eee47, type: 3}
       propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 7463538678728492438, guid: 1d428997838859f49867c1e16c0eee47, type: 3}
+      propertyPath: m_IsActive
       value: 0
       objectReference: {fileID: 0}
     m_RemovedComponents: []
@@ -597,6 +605,7 @@ RectTransform:
   - {fileID: 1150060204}
   - {fileID: 861749498}
   - {fileID: 424505317}
+  - {fileID: 2090067709}
   m_Father: {fileID: 1103402384}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -1659,3 +1668,151 @@ Transform:
   m_Father: {fileID: 0}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &2090067708
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2090067709}
+  - component: {fileID: 2090067711}
+  - component: {fileID: 2090067710}
+  - component: {fileID: 2090067712}
+  m_Layer: 5
+  m_Name: Player Role Choice
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2090067709
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090067708}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 616105112}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: -120}
+  m_SizeDelta: {x: 500, y: 30}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2090067710
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090067708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 'You have selected to play as: '
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_sharedMaterial: {fileID: 2180264, guid: 8f586378b4e144a9851e7b34d9b748ee, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294828544
+  m_fontColor: {r: 0, g: 0.8862745, b: 0.99215686, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 26.85
+  m_fontSizeBase: 24
+  m_fontWeight: 400
+  m_enableAutoSizing: 1
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 2
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &2090067711
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090067708}
+  m_CullTransparentMesh: 1
+--- !u!114 &2090067712
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2090067708}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: a4a6d7e9ae156b14887cbaf56b858007, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textObject: {fileID: 2090067710}

--- a/Assets/Scripts/Room/LevelSelectManager.cs
+++ b/Assets/Scripts/Room/LevelSelectManager.cs
@@ -70,6 +70,7 @@ public class LevelSelectManager : MonoBehaviourPunCallbacks
         base.OnPlayerLeftRoom(otherPlayer);
 
         PhotonNetwork.LoadLevel(roleSelectSceneName);
+        ResetLevelChoice();
     }
 
     private bool CanStart()
@@ -120,5 +121,6 @@ public class LevelSelectManager : MonoBehaviourPunCallbacks
     private void RPC_LoadRoleSelectLevel()
     {
         PhotonNetwork.LoadLevel(roleSelectSceneName);
+        ResetLevelChoice();
     }
 }

--- a/Assets/Scripts/UI/RoleChoice.cs
+++ b/Assets/Scripts/UI/RoleChoice.cs
@@ -1,0 +1,35 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using TMPro;
+using Photon.Pun;
+
+using PlayerType = RoleSelectManager.PlayerType;
+
+public class RoleChoice : MonoBehaviour
+{
+    public static readonly string PLAYER_CHOICE_KNIGHT = "KNIGHT";
+    public static readonly string PLAYER_CHOICE_DRAGON = "DRAGON";
+    public static readonly string PLAYER_CHOICE_ERROR = "Something went wrong. Please reselect your role.";
+
+    [SerializeField] private TextMeshProUGUI textObject;
+
+    private void Start()
+    {
+        PlayerType playerType = (PlayerType)PhotonNetwork.LocalPlayer.
+            CustomProperties[PlayerSpawner.PLAYER_PROPERTIES_TYPE_KEY];
+
+        switch (playerType)
+        {
+            case PlayerType.KNIGHT:
+                textObject.text += PLAYER_CHOICE_KNIGHT;
+                break;
+            case PlayerType.DRAGON:
+                textObject.text += PLAYER_CHOICE_DRAGON;
+                break;
+            default:
+                textObject.text = PLAYER_CHOICE_ERROR;
+                return;
+        }
+    }
+}

--- a/Assets/Scripts/UI/RoleChoice.cs.meta
+++ b/Assets/Scripts/UI/RoleChoice.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: a4a6d7e9ae156b14887cbaf56b858007
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/RoomCode.cs
+++ b/Assets/Scripts/UI/RoomCode.cs
@@ -6,7 +6,7 @@ using Photon.Pun;
 
 public class RoomCode : MonoBehaviour
 {
-    [SerializeField] TextMeshProUGUI textObject;
+    [SerializeField] private TextMeshProUGUI textObject;
 
     private void Start()
     {


### PR DESCRIPTION
Resolves #61 

Let's:
* Add a new text UI element to LevelSelect scene to show what role the player had selected in role select. This is a simple QoL change in case the player forgets the role they have selected.
* Fix issues regarding players' level choices not being cleared when exiting level select or exiting the room.

![image](https://user-images.githubusercontent.com/77261657/158996178-5c9ba20a-8afa-4a0c-9a7f-982a2bd07de6.png)
![image](https://user-images.githubusercontent.com/77261657/158996285-8b204ff9-3db2-49f0-93d6-d7abad67f1ee.png)
