### PR TITLE
Prototype revival mechanic

### DIFF
--- a/Assets/Animations/Dragon/Dragon.controller
+++ b/Assets/Animations/Dragon/Dragon.controller
@@ -77,6 +77,9 @@ AnimatorStateMachine:
   - serializedVersion: 1
     m_State: {fileID: 944696802616655711}
     m_Position: {x: 280, y: -60, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: -3342509083118118260}
+    m_Position: {x: 550, y: 20, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: 3439081241796482835}
@@ -182,7 +185,8 @@ AnimatorState:
   m_Name: Death
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: -2508198199416585224}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -301,6 +305,83 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-3769719051344437692
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isReviving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 6828897138525151247}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &-3342509083118118260
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Revive
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -3769719051344437692}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: f153c1dbd82e3a34894918a0ed57f8f9, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1101 &-2508198199416585224
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isReviving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -3342509083118118260}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!91 &9100000
 AnimatorController:
   m_ObjectHideFlags: 0
@@ -347,6 +428,12 @@ AnimatorController:
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
   - m_Name: isDead
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  - m_Name: isReviving
     m_Type: 4
     m_DefaultFloat: 0
     m_DefaultInt: 0
@@ -778,6 +865,9 @@ AnimatorStateTransition:
   m_PrefabAsset: {fileID: 0}
   m_Name: 
   m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isFalling
+    m_EventTreshold: 0
   - m_ConditionMode: 1
     m_ConditionEvent: isDead
     m_EventTreshold: 0

--- a/Assets/Animations/Dragon/Revive.anim
+++ b/Assets/Animations/Dragon/Revive.anim
@@ -1,0 +1,96 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Revive
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300000, guid: 224258bdd9be6684ab59125d06346cab, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 14b3655b1807d7e4aa6affc17db360e9, type: 3}
+    - time: 0.25
+      value: {fileID: 21300000, guid: c571b46e42d011147a5f7ae492c55d39, type: 3}
+    - time: 0.375
+      value: {fileID: 21300000, guid: 5947d9b1c0030d145bbb2c35e78f183a, type: 3}
+    - time: 0.5
+      value: {fileID: 21300000, guid: 9603ea79b1e7c7148ba991c5977a6868, type: 3}
+    - time: 0.75
+      value: {fileID: 21300000, guid: 9603ea79b1e7c7148ba991c5977a6868, type: 3}
+    - time: 0.875
+      value: {fileID: 21300000, guid: 14b3655b1807d7e4aa6affc17db360e9, type: 3}
+    - time: 1
+      value: {fileID: 21300000, guid: ce0b898b9e8ab3843a9e24fadc4957a6, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 8
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: 224258bdd9be6684ab59125d06346cab, type: 3}
+    - {fileID: 21300000, guid: 14b3655b1807d7e4aa6affc17db360e9, type: 3}
+    - {fileID: 21300000, guid: c571b46e42d011147a5f7ae492c55d39, type: 3}
+    - {fileID: 21300000, guid: 5947d9b1c0030d145bbb2c35e78f183a, type: 3}
+    - {fileID: 21300000, guid: 9603ea79b1e7c7148ba991c5977a6868, type: 3}
+    - {fileID: 21300000, guid: 9603ea79b1e7c7148ba991c5977a6868, type: 3}
+    - {fileID: 21300000, guid: 14b3655b1807d7e4aa6affc17db360e9, type: 3}
+    - {fileID: 21300000, guid: ce0b898b9e8ab3843a9e24fadc4957a6, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.125
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 0
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 0.875
+    functionName: OnReviveEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/Dragon/Revive.anim.meta
+++ b/Assets/Animations/Dragon/Revive.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: f153c1dbd82e3a34894918a0ed57f8f9
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Knight/Combat/Revive.anim
+++ b/Assets/Animations/Knight/Combat/Revive.anim
@@ -1,0 +1,84 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Revive
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300144, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.53333336
+      value: {fileID: 21300146, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 0.8
+      value: {fileID: 21300148, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - time: 1
+      value: {fileID: 21300148, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 15
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300144, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300146, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300148, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+    - {fileID: 21300148, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 1.0666667
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events:
+  - time: 0.93333334
+    functionName: OnReviveEnd
+    data: 
+    objectReferenceParameter: {fileID: 0}
+    floatParameter: 0
+    intParameter: 0
+    messageOptions: 0

--- a/Assets/Animations/Knight/Combat/Revive.anim.meta
+++ b/Assets/Animations/Knight/Combat/Revive.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: a846b7b202cd02246a0287f226e68afa
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Knight/Knight.controller
+++ b/Assets/Animations/Knight/Knight.controller
@@ -77,6 +77,31 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1101 &-8057882425292114772
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isReviving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 789335908325696031}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
 --- !u!1101 &-7305253901518819743
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -355,7 +380,8 @@ AnimatorState:
   m_Name: Death
   m_Speed: 1
   m_CycleOffset: 0
-  m_Transitions: []
+  m_Transitions:
+  - {fileID: 92446298786236536}
   m_StateMachineBehaviours: []
   m_Position: {x: 50, y: 50, z: 0}
   m_IKOnFeet: 0
@@ -546,6 +572,12 @@ AnimatorController:
     m_DefaultInt: 0
     m_DefaultBool: 0
     m_Controller: {fileID: 0}
+  - m_Name: isReviving
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
   m_AnimatorLayers:
   - serializedVersion: 5
     m_Name: Base Layer
@@ -583,6 +615,31 @@ AnimatorStateTransition:
   m_TransitionOffset: 0
   m_ExitTime: 0
   m_HasExitTime: 1
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1101 &92446298786236536
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isReviving
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 1530230062425779771}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
   m_HasFixedDuration: 0
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
@@ -749,6 +806,33 @@ AnimatorStateTransition:
   m_InterruptionSource: 0
   m_OrderedInterruption: 1
   m_CanTransitionToSelf: 1
+--- !u!1102 &1530230062425779771
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Revive
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -8057882425292114772}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: a846b7b202cd02246a0287f226e68afa, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
 --- !u!1101 &1548461585977022283
 AnimatorStateTransition:
   m_ObjectHideFlags: 1
@@ -825,7 +909,7 @@ AnimatorStateMachine:
     m_Position: {x: 60, y: 60, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -3268997484532825647}
-    m_Position: {x: 360, y: -90, z: 0}
+    m_Position: {x: 520, y: -30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5204554678856530955}
     m_Position: {x: 60, y: 280, z: 0}
@@ -834,10 +918,13 @@ AnimatorStateMachine:
     m_Position: {x: 60, y: 160, z: 0}
   - serializedVersion: 1
     m_State: {fileID: 5511107448079907900}
-    m_Position: {x: 630, y: -20, z: 0}
+    m_Position: {x: 900, y: -30, z: 0}
   - serializedVersion: 1
     m_State: {fileID: -1521945519044275835}
     m_Position: {x: 630, y: -170, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 1530230062425779771}
+    m_Position: {x: 360, y: -170, z: 0}
   m_ChildStateMachines:
   - serializedVersion: 1
     m_StateMachine: {fileID: -1359615185329635890}

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -78,6 +78,9 @@ MonoBehaviour:
   - RPC_SetLayer
   - RPC_SetCollisionLayer
   - RPC_SetSpriteRendererLayer
+  - RPC_Revive
+  - RPC_UpdateDragonHealthUI
+  - RPC_UpdateKnightHealthUI
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -81,6 +81,12 @@ MonoBehaviour:
   - RPC_Revive
   - RPC_UpdateDragonHealthUI
   - RPC_UpdateKnightHealthUI
+  - RPC_DismountRider
+  - RPC_MountRider
+  - RPC_SetIsEnabled
+  - RPC_ToggleAllInteractables
+  - RPC_EnableInteractable
+  - RPC_SetInteractableIsEnabled
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Resources/Dragon Enemy Ranged.prefab
+++ b/Assets/Resources/Dragon Enemy Ranged.prefab
@@ -678,11 +678,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 1
-  decrementHealthEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  photonView: {fileID: 2580839893817942634}
+  maxHealthPoints: 1
 --- !u!114 &2580839893817942635
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -531,11 +531,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 1
-  decrementHealthEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  photonView: {fileID: 6640825776839568949}
+  maxHealthPoints: 1
 --- !u!114 &6640825776839568949
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -466,7 +466,6 @@ MonoBehaviour:
   defaultStoppingDistanceFromNavTargets: 0.91
   navFastDistanceThreshold: 8
   movementSpeed: 2
-  canLandOnGround: 0
 --- !u!114 &7213589635427211298
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -506,6 +505,9 @@ MonoBehaviour:
   deathEvent:
     m_PersistentCalls:
       m_Calls: []
+  reviveEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &7404829110624881476
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -532,6 +534,9 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealthPoints: 1
+  updateHealthEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &6640825776839568949
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -10,7 +10,9 @@ GameObject:
   m_Component:
   - component: {fileID: 2501043989457942554}
   - component: {fileID: 3884554816259593756}
+  - component: {fileID: 6781666556977201290}
   - component: {fileID: 2657584058281478896}
+  - component: {fileID: 9200074913184122050}
   - component: {fileID: 3076819617650144031}
   m_Layer: 13
   m_Name: Interaction
@@ -31,7 +33,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4470413134207635894}
-  m_RootOrder: 5
+  m_RootOrder: 6
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 23.96}
 --- !u!70 &3884554816259593756
 CapsuleCollider2D:
@@ -49,6 +51,19 @@ CapsuleCollider2D:
   m_Offset: {x: 0, y: 0}
   m_Size: {x: 3.267, y: 1.122}
   m_Direction: 1
+--- !u!114 &6781666556977201290
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522193754294946270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 542294f93a6a85f42b8f56dd1a655ad1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 3076819617650144031}
 --- !u!114 &2657584058281478896
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -62,6 +77,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   photonView: {fileID: 3076819617650144031}
+  isEnabledByDefault: 1
   mount: {fileID: 4470413134207635894}
   mountMovement: {fileID: 4470413134207635889}
   localOffset: {x: 0.43, y: 0.923}
@@ -97,6 +113,21 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 1
         m_CallState: 2
+--- !u!114 &9200074913184122050
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1522193754294946270}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cbe12070a0ee3e428ea0ac92e1a90b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 3076819617650144031}
+  isEnabledByDefault: 0
+  combat: {fileID: 3483110514655366300}
 --- !u!114 &3076819617650144031
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -209,8 +240,8 @@ Transform:
   - {fileID: 5960651057919622052}
   - {fileID: 6446324908195120128}
   - {fileID: 614414376297081873}
-  - {fileID: 2501043989457942554}
   - {fileID: 4814071368406173127}
+  - {fileID: 2501043989457942554}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -333,7 +364,6 @@ MonoBehaviour:
   defaultStoppingDistanceFromNavTargets: 1.6
   navFastDistanceThreshold: 8
   movementSpeed: 6
-  canLandOnGround: 0
 --- !u!114 &3483110514655366300
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -379,6 +409,57 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: MountInteractable, Assembly-CSharp
         m_MethodName: MountDeathHandler
         m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 2657584058281478896}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+      - m_Target: {fileID: 9200074913184122050}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+  reviveEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 2657584058281478896}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 9200074913184122050}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -570,7 +651,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4470413134207635894}
-  m_RootOrder: 6
+  m_RootOrder: 5
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!70 &1863661894885430654
 CapsuleCollider2D:
@@ -695,7 +776,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 8714695237697900579}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: -1.007, y: -0.94, z: 0}
+  m_LocalPosition: {x: -0.928, y: -1.035, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4470413134207635894}
@@ -896,6 +977,9 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 2
     Name: isAttackingDown
+  - Type: 4
+    SynchronizeType: 2
+    Name: isReviving
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -210,6 +210,7 @@ Transform:
   - {fileID: 6446324908195120128}
   - {fileID: 614414376297081873}
   - {fileID: 2501043989457942554}
+  - {fileID: 4814071368406173127}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -308,6 +309,7 @@ MonoBehaviour:
   combat: {fileID: 3483110514655366300}
   playerInput: {fileID: 4470413134207635893}
   persistentActionMaps: []
+  interactableDetector: {fileID: 1287844530801011846}
   movement: {fileID: 4470413134207635889}
 --- !u!114 &4470413134207635889
 MonoBehaviour:
@@ -397,11 +399,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 3
-  decrementHealthEvent:
+  maxHealthPoints: 3
+  updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
-  photonView: {fileID: 4470413134207635888}
 --- !u!114 &4470413134207635888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -539,6 +540,66 @@ MonoBehaviour:
   surfacesLayerMask:
     serializedVersion: 2
     m_Bits: 64
+--- !u!1 &6088775069156553585
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 4814071368406173127}
+  - component: {fileID: 1863661894885430654}
+  - component: {fileID: 1287844530801011846}
+  m_Layer: 14
+  m_Name: Interactable Detector
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &4814071368406173127
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6088775069156553585}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0.64, y: 0.08, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 4470413134207635894}
+  m_RootOrder: 6
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!70 &1863661894885430654
+CapsuleCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6088775069156553585}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 0
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_Size: {x: 4, y: 3}
+  m_Direction: 1
+--- !u!114 &1287844530801011846
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6088775069156553585}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 8798ebdf7652f484aaffe843cc83d70f, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &7931140408847185767
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -593,11 +593,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 1
-  decrementHealthEvent:
-    m_PersistentCalls:
-      m_Calls: []
-  photonView: {fileID: 2315394145704112158}
+  maxHealthPoints: 1
 --- !u!114 &8145762069085459480
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -445,6 +445,9 @@ MonoBehaviour:
   deathEvent:
     m_PersistentCalls:
       m_Calls: []
+  reviveEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &7653389214318838471
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -470,11 +470,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 1
-  decrementHealthEvent:
+  maxHealthPoints: 1
+  updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
-  photonView: {fileID: 5693331145748344914}
 --- !u!114 &5693331145748344914
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -121,6 +121,7 @@ GameObject:
   m_Component:
   - component: {fileID: 6128370761676518506}
   - component: {fileID: 3417880824068493907}
+  - component: {fileID: 2350143408308583893}
   - component: {fileID: 795063247648489553}
   - component: {fileID: 642602536449024203}
   m_Layer: 13
@@ -170,6 +171,19 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1.66, y: 1.66}
   m_EdgeRadius: 0
+--- !u!114 &2350143408308583893
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3633289788714468707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 542294f93a6a85f42b8f56dd1a655ad1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 642602536449024203}
 --- !u!114 &795063247648489553
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -183,6 +197,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   photonView: {fileID: 642602536449024203}
+  isEnabledByDefault: 0
   combat: {fileID: 4584270387848782332}
 --- !u!114 &642602536449024203
 MonoBehaviour:
@@ -613,7 +628,34 @@ MonoBehaviour:
       m_Calls: []
   deathEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 795063247648489553}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+  reviveEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 795063247648489553}
+        m_TargetAssemblyTypeName: Interactable, Assembly-CSharp
+        m_MethodName: SetIsEnabledWithSync
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!114 &5726660194417758549
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -111,6 +111,101 @@ MonoBehaviour:
   blockHitEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!1 &3633289788714468707
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 6128370761676518506}
+  - component: {fileID: 3417880824068493907}
+  - component: {fileID: 795063247648489553}
+  - component: {fileID: 642602536449024203}
+  m_Layer: 13
+  m_Name: Interaction
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &6128370761676518506
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3633289788714468707}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: -0.31, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 5696632616774609734}
+  m_RootOrder: 7
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!61 &3417880824068493907
+BoxCollider2D:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3633289788714468707}
+  m_Enabled: 1
+  m_Density: 1
+  m_Material: {fileID: 0}
+  m_IsTrigger: 1
+  m_UsedByEffector: 0
+  m_UsedByComposite: 0
+  m_Offset: {x: 0, y: 0}
+  m_SpriteTilingProperty:
+    border: {x: 0, y: 0, z: 0, w: 0}
+    pivot: {x: 0, y: 0}
+    oldSize: {x: 0, y: 0}
+    newSize: {x: 0, y: 0}
+    adaptiveTilingThreshold: 0
+    drawMode: 0
+    adaptiveTiling: 0
+  m_AutoTiling: 0
+  serializedVersion: 2
+  m_Size: {x: 1.66, y: 1.66}
+  m_EdgeRadius: 0
+--- !u!114 &795063247648489553
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3633289788714468707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 7cbe12070a0ee3e428ea0ac92e1a90b1, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 642602536449024203}
+  combat: {fileID: 4584270387848782332}
+--- !u!114 &642602536449024203
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 3633289788714468707}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &3657565083484446672
 GameObject:
   m_ObjectHideFlags: 0
@@ -303,6 +398,7 @@ Transform:
   - {fileID: 1784289309786822353}
   - {fileID: 1961698731118320924}
   - {fileID: 8788491003870426397}
+  - {fileID: 6128370761676518506}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -449,8 +545,8 @@ MonoBehaviour:
   combat: {fileID: 4584270387848782332}
   playerInput: {fileID: 5696632616774609755}
   persistentActionMaps: []
-  movement: {fileID: 6669902685249964190}
   interactableDetector: {fileID: 6397929481459963310}
+  movement: {fileID: 6669902685249964190}
 --- !u!114 &6669902685249964190
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -530,11 +626,10 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: e7d2f6eff6a7c9f4e8d0e3da4a091335, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  healthPoints: 3
-  decrementHealthEvent:
+  maxHealthPoints: 3
+  updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
-  photonView: {fileID: 5696632616774609759}
 --- !u!114 &4828491241966369471
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -791,6 +886,9 @@ MonoBehaviour:
   - Type: 4
     SynchronizeType: 2
     Name: isWalking
+  - Type: 4
+    SynchronizeType: 2
+    Name: isReviving
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0
@@ -820,7 +918,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7499006096477850584}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: 0, y: -0.31, z: 0}
+  m_LocalPosition: {x: 0.466, y: -0.431, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 5696632616774609734}
@@ -850,7 +948,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 1.66, y: 1.66}
+  m_Size: {x: 1, y: 1.5}
   m_EdgeRadius: 0
 --- !u!114 &6397929481459963310
 MonoBehaviour:

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -196,4 +196,9 @@ public class Combat : MonoBehaviour
             buff.RemoveBuff();
         }
     }
+
+    public void Revive()
+    {
+        CombatStateMachine.ChangeState(new ReviveState(this));
+    }
 }

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -46,6 +46,7 @@ public class Combat : MonoBehaviour
     [SerializeField] private RangedProjectileEvent actorFiredProjectileEvent;
     [SerializeField] private UnityEvent hurtEvent;
     [SerializeField] private UnityEvent deathEvent;
+    [SerializeField] private UnityEvent reviveEvent;
 
     private Dictionary<CombatAbilityIdentifier, CombatAbility> identifierToAbilityDictionary
         = new Dictionary<CombatAbilityIdentifier, CombatAbility>();
@@ -65,6 +66,7 @@ public class Combat : MonoBehaviour
 
     public UnityEvent HurtEvent { get => hurtEvent; }
     public UnityEvent DeathEvent { get => deathEvent; }
+    public UnityEvent ReviveEvent { get => reviveEvent; }
 
     public CombatStateMachine CombatStateMachine { get; private set; }
 

--- a/Assets/Scripts/Actor Components/Combat/CombatAnimationEventHandler.cs
+++ b/Assets/Scripts/Actor Components/Combat/CombatAnimationEventHandler.cs
@@ -38,4 +38,12 @@ public class CombatAnimationEventHandler : MonoBehaviour
             combat.CombatStateMachine.Exit();
         }
     }
+
+    public void OnReviveEnd()
+    {
+        if (combat.CombatStateMachine.CurrState is ReviveState)
+        {
+            combat.CombatStateMachine.Exit();
+        }
+    }
 }

--- a/Assets/Scripts/Actor Components/Health.cs
+++ b/Assets/Scripts/Actor Components/Health.cs
@@ -2,33 +2,38 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
-using Photon.Pun;
-using Photon.Realtime;
+
+[System.Serializable]
+public class HealthUpdateEvent : UnityEvent<int> { }
 
 public class Health : MonoBehaviour
 {
-    [SerializeField] private int healthPoints;
-    [SerializeField] private UnityEvent decrementHealthEvent;
-    [SerializeField] private PhotonView photonView;
+    [SerializeField] private int maxHealthPoints;
+    [SerializeField] private HealthUpdateEvent updateHealthEvent;
 
-    public int HealthPoints { get => healthPoints; }
+    public int CurrHealthPoints { get; private set; }
 
-    public UnityEvent DecrementHealthEvent { get => decrementHealthEvent; }
+    public HealthUpdateEvent UpdateHealthEvent { get => updateHealthEvent; }
+
+    private void Awake()
+    {
+        CurrHealthPoints = maxHealthPoints;
+    }
+
+    public void SetMax()
+    {
+        CurrHealthPoints = maxHealthPoints;
+        updateHealthEvent.Invoke(CurrHealthPoints);
+    }
 
     public void Decrement()
     {
-        photonView.RPC("RPC_Decrement", RpcTarget.All);
-    }
-
-    [PunRPC]
-    private void RPC_Decrement()
-    {
-        healthPoints = Mathf.Max(0, healthPoints - 1);
-        decrementHealthEvent.Invoke();
+        CurrHealthPoints = Mathf.Max(0, CurrHealthPoints - 1);
+        updateHealthEvent.Invoke(CurrHealthPoints);
     }
 
     public bool IsZero()
     {
-        return healthPoints == 0;
+        return CurrHealthPoints == 0;
     }
 }

--- a/Assets/Scripts/Actor Components/InteractableDetector.cs
+++ b/Assets/Scripts/Actor Components/InteractableDetector.cs
@@ -18,6 +18,11 @@ public class InteractableDetector : MonoBehaviour
         float nearestInteractableDistance = Mathf.Infinity;
         foreach (Interactable interactable in interactablesInRange)
         {
+            if (!interactable.IsEnabled)
+            {
+                continue;
+            }
+
             float distanceToInteractable = Vector2.Distance(currPosition, interactable.transform.position);
             if (distanceToInteractable < nearestInteractableDistance)
             {
@@ -31,8 +36,8 @@ public class InteractableDetector : MonoBehaviour
 
     private void OnTriggerEnter2D(Collider2D collision)
     {
-        Interactable interactable = collision.GetComponent<Interactable>();
-        if (interactable != null)
+        Interactable[] interactables = collision.GetComponents<Interactable>();
+        foreach (Interactable interactable in interactables)
         {
             interactablesInRange.Add(interactable);
         }
@@ -40,8 +45,8 @@ public class InteractableDetector : MonoBehaviour
 
     private void OnTriggerExit2D(Collider2D collision)
     {
-        Interactable interactable = collision.GetComponent<Interactable>();
-        if (interactable != null)
+        Interactable[] interactables = collision.GetComponents<Interactable>();
+        foreach (Interactable interactable in interactables)
         {
             interactablesInRange.Remove(interactable);
         }

--- a/Assets/Scripts/Actor Components/Movement/AirMovement.cs
+++ b/Assets/Scripts/Actor Components/Movement/AirMovement.cs
@@ -9,11 +9,8 @@ public class AirMovement : Movement
     [Header("Aerial Movement")]
 
     [SerializeField] private float movementSpeed;
-    [SerializeField] private bool canLandOnGround;
 
     private AirMovementStateMachine movementStateMachine;
-
-    public bool CanLandOnGround { get => canLandOnGround; set => canLandOnGround = value; }
 
     public bool IsGravityEnabled { get; private set; }
 
@@ -28,7 +25,7 @@ public class AirMovement : Movement
     protected override void Start()
     {
         base.Start();
-        MovementStateMachine.ChangeState(new AirborneState(this));
+        TakeFlight();
     }
 
     public override void UpdateMovement(Vector2 direction)
@@ -57,5 +54,10 @@ public class AirMovement : Movement
         {
             MovementStateMachine.ChangeState(new FallingState(this));
         }
+    }
+
+    public void TakeFlight()
+    {
+        MovementStateMachine.ChangeState(new AirborneState(this));
     }
 }

--- a/Assets/Scripts/Actor Components/Movement/GroundMovement.cs
+++ b/Assets/Scripts/Actor Components/Movement/GroundMovement.cs
@@ -84,7 +84,7 @@ public class GroundMovement : Movement
         if (MovementStateMachine.CurrState is GroundedState || MovementStateMachine.CurrState is AirborneState)
         {
             MovementStateMachine.ChangeState(new MountedState(this, mountMovement));
-            photonView.RPC("RPC_Mount", RpcTarget.All,
+            photonView.RPC("RPC_MountRider", RpcTarget.All,
                 mount.GetComponent<PhotonView>().ViewID, localOffset.x, localOffset.y, mountedSortingLayer, mountedSortingLayerOrder);
         }
     }
@@ -94,12 +94,12 @@ public class GroundMovement : Movement
         if (MovementStateMachine.CurrState is MountedState)
         {
             MovementStateMachine.ChangeState(new AirborneState(this));
-            photonView.RPC("RPC_Dismount", RpcTarget.All);
+            photonView.RPC("RPC_DismountRider", RpcTarget.All);
         }
     }
 
     [PunRPC]
-    private void RPC_Mount(int mountViewId, float localOffsetX, float localOffsetY,
+    private void RPC_MountRider(int mountViewId, float localOffsetX, float localOffsetY,
         SpriteLayer.Layer mountedSortingLayer, int mountedSortingLayerOrder)
     {
         rigidbody2d.isKinematic = true;
@@ -114,7 +114,7 @@ public class GroundMovement : Movement
     }
 
     [PunRPC]
-    private void RPC_Dismount()
+    private void RPC_DismountRider()
     {
         transform.parent = null;
         rigidbody2d.isKinematic = false;

--- a/Assets/Scripts/Actor Controllers/ActorController.cs
+++ b/Assets/Scripts/Actor Controllers/ActorController.cs
@@ -25,6 +25,7 @@ public abstract class ActorController : MonoBehaviour
         {
             Combat.HurtEvent.AddListener(HandleHurtEvent);
             Combat.DeathEvent.AddListener(HandleDeathEvent);
+            Combat.ReviveEvent.AddListener(HandleReviveEvent);
         }
     }
 
@@ -34,6 +35,7 @@ public abstract class ActorController : MonoBehaviour
         {
             Combat.HurtEvent.RemoveListener(HandleHurtEvent);
             Combat.DeathEvent.RemoveListener(HandleDeathEvent);
+            Combat.ReviveEvent.RemoveListener(HandleReviveEvent);
         }
     }
 
@@ -61,4 +63,6 @@ public abstract class ActorController : MonoBehaviour
     protected virtual void HandleHurtEvent() { }
 
     protected virtual void HandleDeathEvent() { }
+
+    protected virtual void HandleReviveEvent() { }
 }

--- a/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
+++ b/Assets/Scripts/Actor Controllers/DragonEnemyController.cs
@@ -25,7 +25,6 @@ public class DragonEnemyController : EnemyController
     protected override void HandleDeathEvent()
     {
         base.HandleDeathEvent();
-        movement.CanLandOnGround = true;
         movement.ToggleGravity(true);
     }
 }

--- a/Assets/Scripts/Actor Controllers/RangedKnightEnemyController.cs
+++ b/Assets/Scripts/Actor Controllers/RangedKnightEnemyController.cs
@@ -24,7 +24,6 @@ public class RangedKnightEnemyController : EnemyController
     protected override void HandleDeathEvent()
     {
         base.HandleDeathEvent();
-        movement.CanLandOnGround = true;
         movement.ToggleGravity(true);
     }
 }

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -42,6 +42,7 @@ public class DragonPlayerController : PlayerController
             movement.UpdateMovement(new Vector2(horizontalMovementInput, verticalMovementInput));
         }
     }
+
     protected override void OnEnable()
     {
         base.OnEnable();
@@ -143,7 +144,13 @@ public class DragonPlayerController : PlayerController
     protected override void HandleDeathEvent()
     {
         base.HandleDeathEvent();
-        movement.CanLandOnGround = true;
         movement.ToggleGravity(true);
+    }
+
+    protected override void HandleReviveEvent()
+    {
+        base.HandleReviveEvent();
+        movement.ToggleGravity(false);
+        movement.TakeFlight();
     }
 }

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -12,6 +12,7 @@ public class DragonPlayerController : PlayerController
     private InputAction rangedAttackAction;
     private InputAction rangedAttackDownAction;
     private InputAction dodgeAction;
+    private InputAction interactAction;
 
     private HealthUI healthUI;
 
@@ -28,6 +29,7 @@ public class DragonPlayerController : PlayerController
         rangedAttackAction = playerInput.actions["RangedAttack"];
         rangedAttackDownAction = playerInput.actions["RangedAttackDown"];
         dodgeAction = playerInput.actions["AirDodge"];
+        interactAction = playerInput.actions["InteractAir"];
 
         healthUI = GameObject.FindObjectOfType<HealthUI>();
     }
@@ -46,7 +48,7 @@ public class DragonPlayerController : PlayerController
 
         if (photonView.IsMine)
         {
-            Combat.Health.DecrementHealthEvent.AddListener(healthUI.DecrementDragonHealthUI);
+            Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateDragonHealthUI);
         }
     }
 
@@ -56,7 +58,7 @@ public class DragonPlayerController : PlayerController
 
         if (photonView.IsMine)
         {
-            Combat.Health.DecrementHealthEvent.RemoveListener(healthUI.DecrementDragonHealthUI);
+            Combat.Health.UpdateHealthEvent.RemoveListener(healthUI.UpdateDragonHealthUI);
         }
     }
 
@@ -67,6 +69,7 @@ public class DragonPlayerController : PlayerController
         rangedAttackAction.performed += HandleRangedAttackInput;
         rangedAttackDownAction.performed += HandleRangedAttackDownInput;
         dodgeAction.performed += HandleDodgeInput;
+        interactAction.performed += HandleInteractInput;
     }
 
     protected override void UnbindInputActionHandlers()
@@ -76,6 +79,7 @@ public class DragonPlayerController : PlayerController
         rangedAttackAction.performed -= HandleRangedAttackInput;
         rangedAttackDownAction.performed -= HandleRangedAttackDownInput;
         dodgeAction.performed -= HandleDodgeInput;
+        interactAction.performed -= HandleInteractInput;
     }
 
     private void HandleMoveAirHorizontalInput(InputAction.CallbackContext context)
@@ -123,6 +127,19 @@ public class DragonPlayerController : PlayerController
             combat.ExecuteCombatAbility(CombatAbilityIdentifier.DODGE, direction);
         }
     }
+
+    private void HandleInteractInput(InputAction.CallbackContext context)
+    {
+        if (combat.CombatStateMachine.CurrState == null)
+        {
+            Interactable nearestInteractable = interactableDetector.GetNearestInteractable();
+            if (nearestInteractable != null)
+            {
+                Interact(nearestInteractable);
+            }
+        }
+    }
+
     protected override void HandleDeathEvent()
     {
         base.HandleDeathEvent();

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -6,7 +6,6 @@ using UnityEngine.InputSystem;
 public class KnightPlayerController : PlayerController
 {
     [SerializeField] private GroundMovement movement;
-    [SerializeField] private InteractableDetector interactableDetector;
 
     private InputAction moveGroundAction;
     private InputAction jumpAction;
@@ -49,7 +48,7 @@ public class KnightPlayerController : PlayerController
 
         if (photonView.IsMine)
         {
-            Combat.Health.DecrementHealthEvent.AddListener(healthUI.DecrementKnightHealthUI);
+            Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateKnightHealthUI);
         }
     }
 
@@ -59,7 +58,7 @@ public class KnightPlayerController : PlayerController
 
         if (photonView.IsMine)
         {
-            Combat.Health.DecrementHealthEvent.RemoveListener(healthUI.DecrementKnightHealthUI);
+            Combat.Health.UpdateHealthEvent.RemoveListener(healthUI.UpdateKnightHealthUI);
         }
     }
 

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -128,10 +128,6 @@ public class KnightPlayerController : PlayerController
             {
                 Interact(nearestInteractable);
             }
-            else if (movement.MovementStateMachine.CurrState is GroundMovementStates.MountedState)
-            {
-                movement.Dismount();
-            }
         }
     }
 

--- a/Assets/Scripts/Input/PlayerController.cs
+++ b/Assets/Scripts/Input/PlayerController.cs
@@ -7,6 +7,7 @@ public abstract class PlayerController : ActorController
 {
     [SerializeField] protected PlayerInput playerInput;
     [SerializeField] protected List<string> persistentActionMaps = new List<string>();
+    [SerializeField] protected InteractableDetector interactableDetector;
 
     private InputAction menuAction;
 

--- a/Assets/Scripts/Input/PlayerControls.inputactions
+++ b/Assets/Scripts/Input/PlayerControls.inputactions
@@ -199,6 +199,15 @@
                     "processors": "",
                     "interactions": "",
                     "initialStateCheck": false
+                },
+                {
+                    "name": "InteractAir",
+                    "type": "Button",
+                    "id": "093b5dce-79ea-4054-a46e-2204dd6a26c6",
+                    "expectedControlType": "Button",
+                    "processors": "",
+                    "interactions": "",
+                    "initialStateCheck": false
                 }
             ],
             "bindings": [
@@ -298,6 +307,17 @@
                     "processors": "",
                     "groups": "",
                     "action": "RangedAttackDown",
+                    "isComposite": false,
+                    "isPartOfComposite": false
+                },
+                {
+                    "name": "",
+                    "id": "ee847bd7-a944-4f70-8fbd-d68dc9145b30",
+                    "path": "<Keyboard>/e",
+                    "interactions": "",
+                    "processors": "",
+                    "groups": "",
+                    "action": "InteractAir",
                     "isComposite": false,
                     "isPartOfComposite": false
                 }

--- a/Assets/Scripts/Interactables/Interactable.cs
+++ b/Assets/Scripts/Interactables/Interactable.cs
@@ -1,6 +1,33 @@
 using UnityEngine;
+using Photon.Pun;
 
 public abstract class Interactable : MonoBehaviour
 {
+    public enum Interaction
+    {
+        MOUNT, REVIVE
+    }
+
+    [SerializeField] protected PhotonView photonView;
+    [SerializeField] protected bool isEnabledByDefault;
+
+    public bool IsEnabled { get; protected set; }
+    public abstract Interaction InteractableInteraction { get; }
+
+    protected virtual void Awake()
+    {
+        IsEnabled = isEnabledByDefault;
+    }
+
     public abstract void Interact(ActorController initiator);
+
+    public void SetIsEnabledWithoutSync(bool isEnabled)
+    {
+        IsEnabled = isEnabled;
+    }
+
+    public void SetIsEnabledWithSync(bool isEnabled)
+    {
+        photonView.RPC("RPC_SetInteractableIsEnabled", RpcTarget.All, InteractableInteraction, isEnabled);
+    }
 }

--- a/Assets/Scripts/Interactables/InteractablesManager.cs
+++ b/Assets/Scripts/Interactables/InteractablesManager.cs
@@ -1,0 +1,27 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class InteractablesManager : MonoBehaviour
+{
+    [SerializeField] private PhotonView photonView;
+
+    private Dictionary<Interactable.Interaction, Interactable> interactables
+        = new Dictionary<Interactable.Interaction, Interactable>();
+
+    private void Awake()
+    {
+        Interactable[] interactablesList = GetComponents<Interactable>();
+        foreach (Interactable interactable in interactablesList)
+        {
+            interactables[interactable.InteractableInteraction] = interactable;
+        }
+    }
+
+    [PunRPC]
+    private void RPC_SetInteractableIsEnabled(Interactable.Interaction interactable, bool isEnabled)
+    {
+        interactables[interactable].SetIsEnabledWithoutSync(isEnabled);
+    }
+}

--- a/Assets/Scripts/Interactables/InteractablesManager.cs.meta
+++ b/Assets/Scripts/Interactables/InteractablesManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 542294f93a6a85f42b8f56dd1a655ad1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactables/MountInteractable.cs
+++ b/Assets/Scripts/Interactables/MountInteractable.cs
@@ -2,15 +2,10 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using UnityEngine.Events;
-using GroundMovementStates;
 using Photon.Pun;
 
 public class MountInteractable : Interactable
 {
-    [SerializeField] private PhotonView photonView;
-    
-    [Space(10)]
-
     [SerializeField] private Transform mount;
     [SerializeField] private Movement mountMovement;
     [SerializeField] private Vector2 localOffset;
@@ -28,24 +23,27 @@ public class MountInteractable : Interactable
 
     private GroundMovement currentRiderMovement = null;
 
+    public override Interaction InteractableInteraction { get => Interaction.MOUNT; }
+
     public override void Interact(ActorController initiator)
     {
-        if (initiator.Movement is GroundMovement groundMovement)
+        if (!IsEnabled || !(initiator.Movement is GroundMovement groundMovement))
         {
-            if (groundMovement.MovementStateMachine.CurrState is MountedState)
-            {
-                // dismount
-                currentRiderMovement = null;
-                groundMovement.Dismount();
-                photonView.RPC("RPC_Dismount", RpcTarget.Others);
-            }
-            else
-            {
-                // mount
-                currentRiderMovement = groundMovement;
-                groundMovement.Mount(mount, mountMovement, localOffset, mountedSpriteLayer, mountedSpriteLayerOrder);
-                photonView.RPC("RPC_Mount", RpcTarget.Others);
-            }
+            return;
+        }
+
+        if (initiator.Movement.MovementStateMachine.CurrState is GroundMovementStates.MountedState)
+        {
+            currentRiderMovement = null;
+            groundMovement.Dismount();
+            photonView.RPC("RPC_Dismount", RpcTarget.Others);
+        }
+        else
+        {
+            // mount
+            currentRiderMovement = groundMovement;
+            groundMovement.Mount(mount, mountMovement, localOffset, mountedSpriteLayer, mountedSpriteLayerOrder);
+            photonView.RPC("RPC_Mount", RpcTarget.Others);
         }
     }
 

--- a/Assets/Scripts/Interactables/ReviveInteractable.cs
+++ b/Assets/Scripts/Interactables/ReviveInteractable.cs
@@ -1,0 +1,25 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class ReviveInteractable : Interactable
+{
+    [SerializeField] private PhotonView photonView;
+    [SerializeField] private Combat combat;
+
+    public override void Interact(ActorController initiator)
+    {
+        photonView.RPC("RPC_Revive", RpcTarget.All);
+    }
+
+    [PunRPC]
+    private void RPC_Revive()
+    {
+        // executed on dead actor's client
+        if (combat.CombatStateMachine.CurrState is CombatStates.DeathState)
+        {
+            combat.Revive();
+        }
+    }
+}

--- a/Assets/Scripts/Interactables/ReviveInteractable.cs
+++ b/Assets/Scripts/Interactables/ReviveInteractable.cs
@@ -5,20 +5,26 @@ using Photon.Pun;
 
 public class ReviveInteractable : Interactable
 {
-    [SerializeField] private PhotonView photonView;
     [SerializeField] private Combat combat;
+
+    public override Interaction InteractableInteraction { get => Interaction.REVIVE; }
 
     public override void Interact(ActorController initiator)
     {
+        if (!IsEnabled)
+        {
+            return;
+        }
+
         photonView.RPC("RPC_Revive", RpcTarget.All);
     }
 
     [PunRPC]
     private void RPC_Revive()
     {
-        // executed on dead actor's client
         if (combat.CombatStateMachine.CurrState is CombatStates.DeathState)
         {
+            // should only execute on dead actor's client
             combat.Revive();
         }
     }

--- a/Assets/Scripts/Interactables/ReviveInteractable.cs.meta
+++ b/Assets/Scripts/Interactables/ReviveInteractable.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 7cbe12070a0ee3e428ea0ac92e1a90b1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/State Machine/State Machines/CombatStateMachine.cs
+++ b/Assets/Scripts/State Machine/State Machines/CombatStateMachine.cs
@@ -15,6 +15,7 @@ public class CombatStateMachine : StateMachine
         transitions[typeof(BlockHitState)] = new HashSet<System.Type>() { typeof(BlockState), typeof(HurtState), typeof(DeathState) };
         transitions[typeof(StunState)] = new HashSet<System.Type>() { typeof(HurtState), typeof(DeathState) };
         transitions[typeof(HurtState)] = new HashSet<System.Type>() { typeof(HurtState), typeof(DeathState) };
-        transitions[typeof(DeathState)] = new HashSet<System.Type>();
+        transitions[typeof(DeathState)] = new HashSet<System.Type>() { typeof(ReviveState) };
+        transitions[typeof(ReviveState)] = new HashSet<System.Type>();
     }
 }

--- a/Assets/Scripts/State Machine/State Machines/Movement State Machines/AirMovementStateMachine.cs
+++ b/Assets/Scripts/State Machine/State Machines/Movement State Machines/AirMovementStateMachine.cs
@@ -10,8 +10,8 @@ namespace StateMachines
         public AirMovementStateMachine()
         {
             transitions[typeof(AirborneState)] = new HashSet<System.Type>() { typeof(FallingState), typeof(GroundedState) };
-            transitions[typeof(FallingState)] = new HashSet<System.Type>() { typeof(GroundedState) };
-            transitions[typeof(GroundedState)] = new HashSet<System.Type>();
+            transitions[typeof(FallingState)] = new HashSet<System.Type>() { typeof(AirborneState), typeof(GroundedState) };
+            transitions[typeof(GroundedState)] = new HashSet<System.Type>() { typeof(AirborneState), typeof(FallingState) };
         }
     }
 }

--- a/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
@@ -6,8 +6,6 @@ namespace CombatStates
 {
     public class DeathState : CombatState
     {
-        private int originalCollisionLayer;
-
         public DeathState(Combat owner) : base(owner) { }
 
         public override void Enter()
@@ -27,8 +25,6 @@ namespace CombatStates
 
         public override void Exit()
         {
-            owner.CollisionLayer.ResetLayer();
-            owner.SpriteLayer.ResetLayer();
             owner.Animator.SetBool("isDead", false);
         }
     }

--- a/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
@@ -24,6 +24,7 @@ namespace CombatStates
         {
             owner.CollisionLayer.ResetLayer();
             owner.Animator.SetBool("isReviving", false);
+            owner.ReviveEvent.Invoke();
         }
     }
 }

--- a/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
@@ -1,0 +1,29 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace CombatStates
+{
+    public class ReviveState : CombatState
+    {
+        public ReviveState(Combat owner) : base(owner) { }
+
+        public override void Enter()
+        {
+            owner.Health.SetMax();
+            owner.SpriteLayer.ResetLayer();
+            owner.Animator.SetBool("isReviving", true);
+        }
+
+        public override void Execute()
+        {
+
+        }
+
+        public override void Exit()
+        {
+            owner.CollisionLayer.ResetLayer();
+            owner.Animator.SetBool("isReviving", false);
+        }
+    }
+}

--- a/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs.meta
+++ b/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: b3713f6a02ced7a428e4f8b2baa6a665
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/HealthUI.cs
+++ b/Assets/Scripts/UI/HealthUI.cs
@@ -2,42 +2,50 @@ using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
 using Photon.Pun;
-using Photon.Realtime;
 
 
 public class HealthUI : MonoBehaviour
 {
+    [SerializeField] PhotonView photonView;
     [SerializeField] private GameObject[] dragonHealthUI;
     [SerializeField] private GameObject[] knightHealthUI;
-    [SerializeField] private int dragonHealth;
-    [SerializeField] private int knightHealth;
-    [SerializeField] PhotonView photonView;
 
-    public int DragonHealth { get => dragonHealth; }
-    public int KnightHealth { get => knightHealth; }
-    // Start is called before the first frame update
-
-    public void DecrementDragonHealthUI()
+    public void UpdateDragonHealthUI(int currHealthPoints)
     {
-        photonView.RPC("RPC_DecrementDragonHealthUI", RpcTarget.All);
+        photonView.RPC("RPC_UpdateDragonHealthUI", RpcTarget.All, currHealthPoints);
     }
 
-    public void DecrementKnightHealthUI()
+    public void UpdateKnightHealthUI(int currHealthPoints)
     {
-        photonView.RPC("RPC_DecrementKnightHealthUI", RpcTarget.All);
+        photonView.RPC("RPC_UpdateKnightHealthUI", RpcTarget.All, currHealthPoints);
     }
 
     [PunRPC]
-    private void RPC_DecrementDragonHealthUI()
+    private void RPC_UpdateDragonHealthUI(int currHealthPoints)
     {
-        dragonHealth = Mathf.Max(0, dragonHealth - 1);
-        dragonHealthUI[dragonHealth].SetActive(false);
+        for (int i = 0; i < currHealthPoints; i++)
+        {
+            dragonHealthUI[i].SetActive(true);
+        }
+
+        for (int i = currHealthPoints; i < dragonHealthUI.Length; i++)
+        {
+            dragonHealthUI[i].SetActive(false);
+        }
     }
 
     [PunRPC]
-    private void RPC_DecrementKnightHealthUI()
+    private void RPC_UpdateKnightHealthUI(int currHealthPoints)
     {
-        knightHealth = Mathf.Max(0, knightHealth - 1);
-        knightHealthUI[knightHealth].SetActive(false);
+        print($"{currHealthPoints}");
+        for (int i = 0; i < currHealthPoints; i++)
+        {
+            knightHealthUI[i].SetActive(true);
+        }
+
+        for (int i = currHealthPoints; i < dragonHealthUI.Length; i++)
+        {
+            knightHealthUI[i].SetActive(false);
+        }
     }
 }

--- a/Assets/Scripts/UI/HealthUI.cs
+++ b/Assets/Scripts/UI/HealthUI.cs
@@ -37,7 +37,6 @@ public class HealthUI : MonoBehaviour
     [PunRPC]
     private void RPC_UpdateKnightHealthUI(int currHealthPoints)
     {
-        print($"{currHealthPoints}");
         for (int i = 0; i < currHealthPoints; i++)
         {
             knightHealthUI[i].SetActive(true);


### PR DESCRIPTION
Implemented
- Revival of dead players using interaction system
  - A player can now press `E` near a dead player to revive them
  - Upon reviving, a 1-second animation will play of the dead player getting up off the ground (during which they are not targeted by enemies)
  - After revival, enemies will "see" the player again and resume their normal attack pattern
  - The input for reviving only requires a single button press at the moment
  - Revival interaction is only enabled while the player is dead
  - Mount interaction is now disabled while the dragon is dead
- Update to health system
  - Health backend now separately tracks maximum health points and current health points
  - Health backend now exposes an additional `SetMax` method for setting health points to the maximum after revival
  - Health backend no longer updates health points on other clients using RPCs, as all attacks on actors are handled by the client that owns the actor
  - Health UI now generically updates based on the current health points, received from health backend via a `HealthUpdateEvent`, instead of only updating upon health decrementing

Issues
- Revival input should be a long button press
- Possible interaction should generally have a pop-up prompt when nearby, but the prompt for reviving a dead player should always be visible regardless of distance