### PR TITLE
Implement mana/stamina system

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -91,6 +91,8 @@ MonoBehaviour:
   - RPC_RegenerateStaminaUI
   - RPC_UpdateManaUI
   - RPC_UpdateStaminaUI
+  - RPC_StopRegenManaUI
+  - RPC_StopRegenStaminaUI
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -87,6 +87,10 @@ MonoBehaviour:
   - RPC_ToggleAllInteractables
   - RPC_EnableInteractable
   - RPC_SetInteractableIsEnabled
+  - RPC_RegenerateManaUI
+  - RPC_RegenerateStaminaUI
+  - RPC_UpdateManaUI
+  - RPC_UpdateStaminaUI
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Resources/Dragon Enemy Ranged.prefab
+++ b/Assets/Resources/Dragon Enemy Ranged.prefab
@@ -700,10 +700,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 0
+  delayBeforeRegen: 1.5
+  resourcePerSec: 1
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 2580839893817942634}

--- a/Assets/Resources/Dragon Enemy Ranged.prefab
+++ b/Assets/Resources/Dragon Enemy Ranged.prefab
@@ -488,6 +488,7 @@ GameObject:
   - component: {fileID: 2580839893817942633}
   - component: {fileID: 2580839893817942632}
   - component: {fileID: 2580839893817942638}
+  - component: {fileID: 8780044099606125065}
   - component: {fileID: 2580839893817942635}
   - component: {fileID: 2580839893817942634}
   - component: {fileID: 2580839893817942645}
@@ -642,6 +643,7 @@ MonoBehaviour:
     ability: {fileID: 9164543939492879357}
   health: {fileID: 2580839893817942638}
   buff: {fileID: 0}
+  resource: {fileID: 8780044099606125065}
   wallCollisionDetector: {fileID: 2580839894231045049}
   knockbackSpeed: 10
   knockbackDistance: 1.2
@@ -666,6 +668,9 @@ MonoBehaviour:
   deathEvent:
     m_PersistentCalls:
       m_Calls: []
+  reviveEvent:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!114 &2580839893817942638
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -679,6 +684,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealthPoints: 1
+  updateHealthEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &8780044099606125065
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2580839893817942653}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 0
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 2580839893817942634}
 --- !u!114 &2580839893817942635
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -884,6 +912,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   maxRange: 10
   readyDuration: 4
   timeToLock: 3
@@ -906,6 +935,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   canBlockProjectiles: 1
   blockHitDuration: 0.5
   blockHitEvent:

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -553,10 +553,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 0
+  delayBeforeRegen: 1.5
+  resourcePerSec: 1
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 6640825776839568949}

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -327,6 +327,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   isReadyRequired: 1
   readyDuration: 2
   attackEffectArea: {fileID: 7280965100743785369}
@@ -347,6 +348,7 @@ GameObject:
   - component: {fileID: 7213589635427211298}
   - component: {fileID: 7404829110624881476}
   - component: {fileID: 5584288266804474021}
+  - component: {fileID: 4282329958813357994}
   - component: {fileID: 6640825776839568949}
   - component: {fileID: 6640825776839568944}
   - component: {fileID: 6640825776839568951}
@@ -493,6 +495,7 @@ MonoBehaviour:
     ability: {fileID: 458767237906566525}
   health: {fileID: 5584288266804474021}
   buff: {fileID: 0}
+  resource: {fileID: 4282329958813357994}
   wallCollisionDetector: {fileID: 8923394087307039422}
   knockbackSpeed: 0
   knockbackDistance: 0
@@ -537,6 +540,26 @@ MonoBehaviour:
   updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &4282329958813357994
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 6640825776839569100}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 0
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 6640825776839568949}
 --- !u!114 &6640825776839568949
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Dragon Enemy.prefab
+++ b/Assets/Resources/Dragon Enemy.prefab
@@ -561,6 +561,9 @@ MonoBehaviour:
   updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
+  stopRegenResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
   photonView: {fileID: 6640825776839568949}
 --- !u!114 &6640825776839568949
 MonoBehaviour:

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -98,6 +98,18 @@ MonoBehaviour:
           m_StringArgument: 
           m_BoolArgument: 0
         m_CallState: 2
+      - m_Target: {fileID: -8994959269452998378}
+        m_TargetAssemblyTypeName: ConsumableResource, Assembly-CSharp
+        m_MethodName: StopRegeneration
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   dismountEvent:
     m_PersistentCalls:
       m_Calls:
@@ -105,6 +117,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: Combat, Assembly-CSharp
         m_MethodName: ToggleCombatAbilities
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: -8994959269452998378}
+        m_TargetAssemblyTypeName: ConsumableResource, Assembly-CSharp
+        m_MethodName: RestartRegeneration
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -499,10 +499,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 100
+  delayBeforeRegen: 1.5
+  resourcePerSec: 10
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 4470413134207635888}

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -214,6 +214,7 @@ GameObject:
   - component: {fileID: 4470413134207635889}
   - component: {fileID: 3483110514655366300}
   - component: {fileID: 6446500998015482331}
+  - component: {fileID: -8994959269452998378}
   - component: {fileID: 4470413134207635888}
   - component: {fileID: 4470413134207635891}
   - component: {fileID: 4470413134207635890}
@@ -393,6 +394,7 @@ MonoBehaviour:
     ability: {fileID: 591363011492556981}
   health: {fileID: 6446500998015482331}
   buff: {fileID: 0}
+  resource: {fileID: -8994959269452998378}
   wallCollisionDetector: {fileID: 7163776362713714178}
   knockbackSpeed: 0
   knockbackDistance: 0
@@ -484,6 +486,26 @@ MonoBehaviour:
   updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &-8994959269452998378
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4470413134207635880}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 100
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 4470413134207635888}
 --- !u!114 &4470413134207635888
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -726,6 +748,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 30
   maxRange: 0
   readyDuration: 0
   timeToLock: 0
@@ -748,6 +771,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 15
   speed: 20
   distance: 4
 --- !u!1 &8714695237697900579

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -531,6 +531,9 @@ MonoBehaviour:
   updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
+  stopRegenResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
   photonView: {fileID: 4470413134207635888}
 --- !u!114 &4470413134207635888
 MonoBehaviour:

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -420,6 +420,7 @@ GameObject:
   - component: {fileID: 2080431000792514480}
   - component: {fileID: 1860061280274303189}
   - component: {fileID: 4948305080866607028}
+  - component: {fileID: 2369876310287700112}
   - component: {fileID: 8145762069085459480}
   - component: {fileID: 2315394145704112158}
   - component: {fileID: 2072683001291248131}
@@ -541,7 +542,6 @@ MonoBehaviour:
   defaultStoppingDistanceFromNavTargets: 1.4
   navFastDistanceThreshold: 8
   movementSpeed: 2
-  canLandOnGround: 0
 --- !u!114 &1860061280274303189
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -569,6 +569,7 @@ MonoBehaviour:
     ability: {fileID: 7085852033703407569}
   health: {fileID: 4948305080866607028}
   buff: {fileID: 0}
+  resource: {fileID: 2369876310287700112}
   wallCollisionDetector: {fileID: 276739738191126824}
   knockbackSpeed: 0
   knockbackDistance: 0
@@ -579,6 +580,9 @@ MonoBehaviour:
     m_PersistentCalls:
       m_Calls: []
   deathEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  reviveEvent:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &4948305080866607028
@@ -594,6 +598,29 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxHealthPoints: 1
+  updateHealthEvent:
+    m_PersistentCalls:
+      m_Calls: []
+--- !u!114 &2369876310287700112
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4861795074019271563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 0
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 2315394145704112158}
 --- !u!114 &8145762069085459480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -725,6 +752,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   maxRange: 5
   readyDuration: 4
   timeToLock: 3

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -614,10 +614,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 0
+  delayBeforeRegen: 1.5
+  resourcePerSec: 1
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 2315394145704112158}

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -501,6 +501,9 @@ MonoBehaviour:
   updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
+  stopRegenResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
   photonView: {fileID: 5693331145748344914}
 --- !u!114 &5693331145748344914
 MonoBehaviour:

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -493,10 +493,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 0
+  delayBeforeRegen: 1.5
+  resourcePerSec: 1
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 5693331145748344914}

--- a/Assets/Resources/Knight Enemy.prefab
+++ b/Assets/Resources/Knight Enemy.prefab
@@ -101,6 +101,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   isReadyRequired: 1
   readyDuration: 2
   attackEffectArea: {fileID: 5693331146226388544}
@@ -283,6 +284,7 @@ GameObject:
   - component: {fileID: 7568959259614269199}
   - component: {fileID: 7653389214318838471}
   - component: {fileID: 707785210333968309}
+  - component: {fileID: 3673420818860114215}
   - component: {fileID: 5693331145748344914}
   - component: {fileID: 5693331145748344915}
   - component: {fileID: 5693331145748344908}
@@ -433,6 +435,7 @@ MonoBehaviour:
     ability: {fileID: 1707262774369454606}
   health: {fileID: 707785210333968309}
   buff: {fileID: 0}
+  resource: {fileID: 3673420818860114215}
   wallCollisionDetector: {fileID: 3776096321984719771}
   knockbackSpeed: 10
   knockbackDistance: 1.2
@@ -477,6 +480,26 @@ MonoBehaviour:
   updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &3673420818860114215
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5693331145748344921}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 0
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 5693331145748344914}
 --- !u!114 &5693331145748344914
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -107,12 +107,24 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
-  resourceCost: 10
+  resourceCost: 0
   canBlockProjectiles: 0
   blockHitDuration: 0.5
   blockHitEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 3995204192595609277}
+        m_TargetAssemblyTypeName: ConsumableResource, Assembly-CSharp
+        m_MethodName: Consume
+        m_Mode: 4
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 10
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
 --- !u!1 &3633289788714468707
 GameObject:
   m_ObjectHideFlags: 0
@@ -514,6 +526,10 @@ MonoBehaviour:
       m_Calls: []
     m_ActionId: 201b485e-954a-41ac-924a-26cff286f9ba
     m_ActionName: Ground/Interact[/Keyboard/e]
+  - m_PersistentCalls:
+      m_Calls: []
+    m_ActionId: 093b5dce-79ea-4054-a46e-2204dd6a26c6
+    m_ActionName: Air/InteractAir[/Keyboard/e]
   m_NeverAutoSwitchControlSchemes: 0
   m_DefaultControlScheme: 
   m_DefaultActionMap: Ground

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -90,6 +90,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 30
   isReadyRequired: 0
   readyDuration: 0
   attackEffectArea: {fileID: 5822808363884121821}
@@ -106,6 +107,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
+  resourceCost: 0
   canBlockProjectiles: 0
   blockHitDuration: 0.5
   blockHitEvent:
@@ -384,6 +386,7 @@ GameObject:
   - component: {fileID: 6669902685249964190}
   - component: {fileID: 4584270387848782332}
   - component: {fileID: 5726660194417758549}
+  - component: {fileID: 3995204192595609277}
   - component: {fileID: 4828491241966369471}
   - component: {fileID: 5696632616774609759}
   - component: {fileID: 5696632616774609756}
@@ -617,6 +620,7 @@ MonoBehaviour:
     ability: {fileID: 4796355272749017670}
   health: {fileID: 5726660194417758549}
   buff: {fileID: 4828491241966369471}
+  resource: {fileID: 3995204192595609277}
   wallCollisionDetector: {fileID: 47246515022818543}
   knockbackSpeed: 10
   knockbackDistance: 1.2
@@ -672,6 +676,26 @@ MonoBehaviour:
   updateHealthEvent:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &3995204192595609277
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 5696632616774609732}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6b3eeb8de5d62be4c97b07611d0d6219, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  maxAmount: 100
+  regenerateResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  consumeResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  photonView: {fileID: 5696632616774609759}
 --- !u!114 &4828491241966369471
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -713,6 +713,9 @@ MonoBehaviour:
   updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
+  stopRegenResourceEvent:
+    m_PersistentCalls:
+      m_Calls: []
   photonView: {fileID: 5696632616774609759}
 --- !u!114 &4828491241966369471
 MonoBehaviour:

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -107,7 +107,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   isEnabled: 1
-  resourceCost: 0
+  resourceCost: 10
   canBlockProjectiles: 0
   blockHitDuration: 0.5
   blockHitEvent:

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -689,10 +689,12 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   maxAmount: 100
+  delayBeforeRegen: 1.5
+  resourcePerSec: 10
   regenerateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
-  consumeResourceEvent:
+  updateResourceEvent:
     m_PersistentCalls:
       m_Calls: []
   photonView: {fileID: 5696632616774609759}

--- a/Assets/Scenes/Test.unity
+++ b/Assets/Scenes/Test.unity
@@ -696,7 +696,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 35, y: 0}
+  m_AnchoredPosition: {x: 35, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &142514747
@@ -1253,6 +1253,80 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: f0496ad1ee0fbb542870b54a45b74b50, type: 3}
+--- !u!1 &331615081
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 331615082}
+  - component: {fileID: 331615084}
+  - component: {fileID: 331615083}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &331615082
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331615081}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1783460113}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &331615083
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331615081}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.85490197, g: 0.85490197, b: 0.85490197, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &331615084
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 331615081}
+  m_CullTransparentMesh: 1
 --- !u!1 &381927663
 GameObject:
   m_ObjectHideFlags: 0
@@ -1896,7 +1970,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 519420028}
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
-  m_LocalPosition: {x: -50.551353, y: 2, z: -20}
+  m_LocalPosition: {x: -49.24852, y: 2, z: -20}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 433622406}
@@ -2146,17 +2220,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 794630386}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 129354756}
-  m_Father: {fileID: 1710262029}
+  m_Father: {fileID: 1355652609}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 100, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 300, y: 150}
   m_Pivot: {x: 0, y: 0.5}
 --- !u!222 &794630388
@@ -2192,7 +2266,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 875541706}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -2201,7 +2275,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 35, y: 0}
+  m_AnchoredPosition: {x: 35, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &875541708
@@ -2267,7 +2341,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 920739362}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -2276,7 +2350,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -15, y: 0}
+  m_AnchoredPosition: {x: -20, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &920739364
@@ -2407,7 +2481,7 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 991003311}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
@@ -2416,7 +2490,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 85, y: 0}
+  m_AnchoredPosition: {x: 90, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &991003313
@@ -2730,6 +2804,81 @@ MonoBehaviour:
   m_BoundingShape2D: {fileID: 958347279}
   m_ConfineScreenEdges: 1
   m_Damping: 0
+--- !u!1 &1218647341
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1218647342}
+  - component: {fileID: 1218647344}
+  - component: {fileID: 1218647343}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1218647342
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218647341}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1363726817}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1218647343
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218647341}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.09411766, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1218647344
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1218647341}
+  m_CullTransparentMesh: 1
 --- !u!1 &1295166054
 GameObject:
   m_ObjectHideFlags: 0
@@ -2843,6 +2992,154 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1298830597}
   m_CullTransparentMesh: 1
+--- !u!1 &1330603102
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1330603103}
+  - component: {fileID: 1330603105}
+  - component: {fileID: 1330603104}
+  m_Layer: 5
+  m_Name: Background
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1330603103
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330603102}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2068160357}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1330603104
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330603102}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0.3254717, g: 0.9109113, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10907, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1330603105
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1330603102}
+  m_CullTransparentMesh: 1
+--- !u!1 &1355652608
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1355652609}
+  m_Layer: 5
+  m_Name: Knight_Stats
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1355652609
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1355652608}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 794630387}
+  - {fileID: 1783460113}
+  m_Father: {fileID: 1710262029}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 100, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1363726816
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1363726817}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1363726817
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1363726816}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1218647342}
+  m_Father: {fileID: 2068160357}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1487838254
 GameObject:
   m_ObjectHideFlags: 0
@@ -2866,17 +3163,17 @@ RectTransform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1487838254}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 406641078}
-  m_Father: {fileID: 1710262029}
-  m_RootOrder: 1
+  m_Father: {fileID: 2025394759}
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -100, y: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 300, y: 150}
   m_Pivot: {x: 1, y: 0.5}
 --- !u!1 &1510196688
@@ -2913,7 +3210,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -15, y: 0}
+  m_AnchoredPosition: {x: -20, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1510196690
@@ -3122,7 +3419,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 85, y: 0}
+  m_AnchoredPosition: {x: 90, y: 5}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1532587116
@@ -3162,6 +3459,81 @@ CanvasRenderer:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1532587114}
+  m_CullTransparentMesh: 1
+--- !u!1 &1545427978
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1545427979}
+  - component: {fileID: 1545427981}
+  - component: {fileID: 1545427980}
+  m_Layer: 5
+  m_Name: Fill
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1545427979
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1545427978}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1721524881}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1545427980
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1545427978}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: fe87c0e1cc204ed48ad3b37840f39efc, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 0, g: 0, b: 0, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_Sprite: {fileID: 10905, guid: 0000000000000000f000000000000000, type: 0}
+  m_Type: 1
+  m_PreserveAspect: 0
+  m_FillCenter: 1
+  m_FillMethod: 4
+  m_FillAmount: 1
+  m_FillClockwise: 1
+  m_FillOrigin: 0
+  m_UseSpriteMesh: 0
+  m_PixelsPerUnitMultiplier: 1
+--- !u!222 &1545427981
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1545427978}
   m_CullTransparentMesh: 1
 --- !u!1001 &1558415172
 PrefabInstance:
@@ -3364,8 +3736,8 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
-  - {fileID: 794630387}
-  - {fileID: 1487838255}
+  - {fileID: 1355652609}
+  - {fileID: 2025394759}
   m_Father: {fileID: 65787071}
   m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -3441,6 +3813,42 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   photonView: {fileID: 1710262032}
   textObject: {fileID: 208754547}
+--- !u!1 &1721524880
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1721524881}
+  m_Layer: 5
+  m_Name: Fill Area
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1721524881
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1721524880}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1545427979}
+  m_Father: {fileID: 1783460113}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.25}
+  m_AnchorMax: {x: 1, y: 0.75}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
+  m_Pivot: {x: 0.5, y: 0.5}
 --- !u!224 &1722338857
 RectTransform:
   m_ObjectHideFlags: 0
@@ -3595,6 +4003,95 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1732394236}
   m_CullTransparentMesh: 1
+--- !u!1 &1783460112
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1783460113}
+  - component: {fileID: 1783460114}
+  m_Layer: 5
+  m_Name: Knight_Stamina
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1783460113
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1783460112}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 331615082}
+  - {fileID: 1721524881}
+  m_Father: {fileID: 1355652609}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: 188, y: -24}
+  m_SizeDelta: {x: 186, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1783460114
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1783460112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 1545427979}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.42
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []
 --- !u!1 &1992689278
 GameObject:
   m_ObjectHideFlags: 0
@@ -3652,3 +4149,129 @@ BoxCollider2D:
   serializedVersion: 2
   m_Size: {x: 1, y: 1}
   m_EdgeRadius: 0
+--- !u!1 &2025394758
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2025394759}
+  m_Layer: 5
+  m_Name: Dragon_Stats
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2025394759
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2025394758}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1487838255}
+  - {fileID: 2068160357}
+  m_Father: {fileID: 1710262029}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 1, y: 0.5}
+  m_AnchorMax: {x: 1, y: 0.5}
+  m_AnchoredPosition: {x: -100, y: 0}
+  m_SizeDelta: {x: 100, y: 100}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &2068160356
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2068160357}
+  - component: {fileID: 2068160358}
+  m_Layer: 5
+  m_Name: Dragon_Stamina
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &2068160357
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068160356}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 1330603103}
+  - {fileID: 1363726817}
+  m_Father: {fileID: 2025394759}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0.5, y: 0.5}
+  m_AnchorMax: {x: 0.5, y: 0.5}
+  m_AnchoredPosition: {x: -112, y: -24}
+  m_SizeDelta: {x: 186, y: 25}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &2068160358
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068160356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 67db9e8f0e2ae9c40bc1e2b64352a6b4, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Navigation:
+    m_Mode: 3
+    m_WrapAround: 0
+    m_SelectOnUp: {fileID: 0}
+    m_SelectOnDown: {fileID: 0}
+    m_SelectOnLeft: {fileID: 0}
+    m_SelectOnRight: {fileID: 0}
+  m_Transition: 1
+  m_Colors:
+    m_NormalColor: {r: 1, g: 1, b: 1, a: 1}
+    m_HighlightedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_PressedColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 1}
+    m_SelectedColor: {r: 0.9607843, g: 0.9607843, b: 0.9607843, a: 1}
+    m_DisabledColor: {r: 0.78431374, g: 0.78431374, b: 0.78431374, a: 0.5019608}
+    m_ColorMultiplier: 1
+    m_FadeDuration: 0.1
+  m_SpriteState:
+    m_HighlightedSprite: {fileID: 0}
+    m_PressedSprite: {fileID: 0}
+    m_SelectedSprite: {fileID: 0}
+    m_DisabledSprite: {fileID: 0}
+  m_AnimationTriggers:
+    m_NormalTrigger: Normal
+    m_HighlightedTrigger: Highlighted
+    m_PressedTrigger: Pressed
+    m_SelectedTrigger: Selected
+    m_DisabledTrigger: Disabled
+  m_Interactable: 0
+  m_TargetGraphic: {fileID: 0}
+  m_FillRect: {fileID: 1218647342}
+  m_HandleRect: {fileID: 0}
+  m_Direction: 0
+  m_MinValue: 0
+  m_MaxValue: 1
+  m_WholeNumbers: 0
+  m_Value: 0.872
+  m_OnValueChanged:
+    m_PersistentCalls:
+      m_Calls: []

--- a/Assets/Scenes/Test.unity
+++ b/Assets/Scenes/Test.unity
@@ -696,7 +696,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 35, y: 5}
+  m_AnchoredPosition: {x: 35, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &142514747
@@ -1258,6 +1258,7 @@ GameObject:
   m_ObjectHideFlags: 0
   m_CorrespondingSourceObject: {fileID: 0}
   m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
   serializedVersion: 6
   m_Component:
   - component: {fileID: 331615082}
@@ -2275,7 +2276,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 35, y: 5}
+  m_AnchoredPosition: {x: 35, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &875541708
@@ -2350,7 +2351,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -20, y: 5}
+  m_AnchoredPosition: {x: -20, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &920739364
@@ -2490,7 +2491,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 90, y: 5}
+  m_AnchoredPosition: {x: 90, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &991003313
@@ -3210,7 +3211,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: -20, y: 5}
+  m_AnchoredPosition: {x: -20, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1510196690
@@ -3419,7 +3420,7 @@ RectTransform:
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0.5, y: 0.5}
   m_AnchorMax: {x: 0.5, y: 0.5}
-  m_AnchoredPosition: {x: 90, y: 5}
+  m_AnchoredPosition: {x: 90, y: 4}
   m_SizeDelta: {x: 40, y: 40}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &1532587116
@@ -3717,6 +3718,7 @@ GameObject:
   - component: {fileID: 1710262030}
   - component: {fileID: 1710262031}
   - component: {fileID: 1710262033}
+  - component: {fileID: 1710262034}
   - component: {fileID: 1710262032}
   m_Layer: 5
   m_Name: InGame_UI
@@ -3766,6 +3768,7 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: eee6c381903ca1b44afd6f3888b595d6, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+  photonView: {fileID: 1710262032}
   dragonHealthUI:
   - {fileID: 1510196688}
   - {fileID: 142514745}
@@ -3774,9 +3777,6 @@ MonoBehaviour:
   - {fileID: 920739362}
   - {fileID: 875541706}
   - {fileID: 991003311}
-  dragonHealth: 3
-  knightHealth: 3
-  photonView: {fileID: 1710262032}
 --- !u!114 &1710262032
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -3813,6 +3813,21 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   photonView: {fileID: 1710262032}
   textObject: {fileID: 208754547}
+--- !u!114 &1710262034
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1710262028}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 58f7fc17b21a38840b578c95c6df0fe2, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  staminaBar: {fileID: 1783460115}
+  manaBar: {fileID: 2068160359}
+  photonView: {fileID: 1710262032}
 --- !u!1 &1721524880
 GameObject:
   m_ObjectHideFlags: 0
@@ -4013,6 +4028,7 @@ GameObject:
   m_Component:
   - component: {fileID: 1783460113}
   - component: {fileID: 1783460114}
+  - component: {fileID: 1783460115}
   m_Layer: 5
   m_Name: Knight_Stamina
   m_TagString: Untagged
@@ -4088,10 +4104,23 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0.42
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &1783460115
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1783460112}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccae87fbc1df1e3469c3ac856cee896d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slider: {fileID: 1783460114}
 --- !u!1 &1992689278
 GameObject:
   m_ObjectHideFlags: 0
@@ -4196,8 +4225,9 @@ GameObject:
   m_Component:
   - component: {fileID: 2068160357}
   - component: {fileID: 2068160358}
+  - component: {fileID: 2068160359}
   m_Layer: 5
-  m_Name: Dragon_Stamina
+  m_Name: Dragon_Mana
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -4271,7 +4301,20 @@ MonoBehaviour:
   m_MinValue: 0
   m_MaxValue: 1
   m_WholeNumbers: 0
-  m_Value: 0.872
+  m_Value: 0
   m_OnValueChanged:
     m_PersistentCalls:
       m_Calls: []
+--- !u!114 &2068160359
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2068160356}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: ccae87fbc1df1e3469c3ac856cee896d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  slider: {fileID: 2068160358}

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/CombatAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/CombatAbility.cs
@@ -11,6 +11,7 @@ public enum CombatAbilityIdentifier
 public abstract class CombatAbility : MonoBehaviour
 {
     [SerializeField] private bool isEnabled = true;
+    [SerializeField] protected float resourceCost;
 
     public bool IsEnabled { get => isEnabled; }
 

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/CombatAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/CombatAbility.cs
@@ -14,6 +14,7 @@ public abstract class CombatAbility : MonoBehaviour
     [SerializeField] protected float resourceCost;
 
     public bool IsEnabled { get => isEnabled; }
+    public float ResourceCost { get => resourceCost; }
 
     public void Toggle(bool isEnabled)
     {

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/DodgeAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/DodgeAbility.cs
@@ -10,7 +10,12 @@ public class DodgeAbility : CombatAbility
 
     public override void Execute(Combat combat, params object[] parameters)
     {
-        Vector2 direction = (Vector2)parameters[0];
-        combat.CombatStateMachine.ChangeState(new DodgeState(combat, direction, speed, distance));
+        if (combat.Resource.CanConsume(resourceCost))
+        {
+            combat.Resource.Consume(resourceCost);
+
+            Vector2 direction = (Vector2)parameters[0];
+            combat.CombatStateMachine.ChangeState(new DodgeState(combat, direction, speed, distance));
+        }
     }
 }

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/MeleeAttackAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/MeleeAttackAbility.cs
@@ -13,19 +13,21 @@ public class MeleeAttackAbility : CombatAbility
 
     public override void Execute(Combat combat, params object[] parameters)
     {
-        if (isReadyRequired)
+        if (combat.Resource.CanConsume(resourceCost))
         {
-            combat.CombatStateMachine.ChangeState(new ReadyAttackState(combat, readyDuration, ReadyCallback));
-        }
-        else if (combat.Resource.CanConsume(resourceCost))
-        {
-            combat.Resource.Consume(resourceCost);
-            combat.CombatStateMachine.ChangeState(new MeleeAttackState(combat, attackEffectArea));
+            if (isReadyRequired)
+            {
+                combat.CombatStateMachine.ChangeState(new ReadyAttackState(combat, readyDuration, ReadyCallback));
+            }
+            else
+            {
+                combat.CombatStateMachine.ChangeState(new MeleeAttackState(combat, attackEffectArea, resourceCost));
+            }
         }
     }
 
     private void ReadyCallback(Combat combat)
     {
-        combat.CombatStateMachine.ChangeState(new MeleeAttackState(combat, attackEffectArea));
+        combat.CombatStateMachine.ChangeState(new MeleeAttackState(combat, attackEffectArea, resourceCost));
     }
 }

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/MeleeAttackAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/MeleeAttackAbility.cs
@@ -17,8 +17,9 @@ public class MeleeAttackAbility : CombatAbility
         {
             combat.CombatStateMachine.ChangeState(new ReadyAttackState(combat, readyDuration, ReadyCallback));
         }
-        else
+        else if (combat.Resource.CanConsume(resourceCost))
         {
+            combat.Resource.Consume(resourceCost);
             combat.CombatStateMachine.ChangeState(new MeleeAttackState(combat, attackEffectArea));
         }
     }

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
@@ -30,19 +30,21 @@ public class RangedAttackAbility : CombatAbility
 
     public override void Execute(Combat combat, params object[] parameters)
     {
-        if (readyDuration > 0f)
+        if (combat.Resource.CanConsume(resourceCost))
         {
-            Transform target = (Transform)parameters[0];
-            combat.CombatStateMachine.ChangeState(new ReadyRangedAttackState(
-                combat, target, projectilePathDisplay, timeToLock, readyDuration, ReadyCallback));
-        }
-        else if (combat.Resource.CanConsume(resourceCost))
-        {
-            combat.Resource.Consume(resourceCost);
-
-            Vector2 direction = (Vector2)parameters[0];
-            combat.CombatStateMachine.ChangeState(new RangedAttackState(
-                combat, projectilePrefab, projectileOrigin, direction, combat.AttackEffectLayer, fireRangedProjectileEvent));
+            if (readyDuration > 0f)
+            {
+                Transform target = (Transform)parameters[0];
+                combat.CombatStateMachine.ChangeState(new ReadyRangedAttackState(
+                    combat, target, projectilePathDisplay, timeToLock, readyDuration, ReadyCallback));
+            }
+            else
+            {
+                Vector2 direction = (Vector2)parameters[0];
+                combat.CombatStateMachine.ChangeState(new RangedAttackState(
+                    combat, projectilePrefab, projectileOrigin, direction, 
+                    combat.AttackEffectLayer, fireRangedProjectileEvent, resourceCost));
+            }
         }
     }
 
@@ -50,6 +52,7 @@ public class RangedAttackAbility : CombatAbility
     {
         Vector2 direction = ((ReadyRangedAttackState)combat.CombatStateMachine.CurrState).TargetPosition - (Vector2)transform.position;
         combat.CombatStateMachine.ChangeState(new RangedAttackState(
-            combat, projectilePrefab, projectileOrigin, direction, combat.AttackEffectLayer, fireRangedProjectileEvent));
+            combat, projectilePrefab, projectileOrigin, direction, 
+            combat.AttackEffectLayer, fireRangedProjectileEvent, resourceCost));
     }
 }

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
@@ -36,8 +36,10 @@ public class RangedAttackAbility : CombatAbility
             combat.CombatStateMachine.ChangeState(new ReadyRangedAttackState(
                 combat, target, projectilePathDisplay, timeToLock, readyDuration, ReadyCallback));
         }
-        else
+        else if (combat.Resource.CanConsume(resourceCost))
         {
+            combat.Resource.Consume(resourceCost);
+
             Vector2 direction = (Vector2)parameters[0];
             combat.CombatStateMachine.ChangeState(new RangedAttackState(
                 combat, projectilePrefab, projectileOrigin, direction, combat.AttackEffectLayer, fireRangedProjectileEvent));

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -183,7 +183,7 @@ public class Combat : MonoBehaviour
 
     public void Buff()
     {
-        if (buff != null && !buff.IsBuffed)
+        if (buff != null)
         {
             buff.ApplyBuff();
         }
@@ -191,7 +191,7 @@ public class Combat : MonoBehaviour
 
     public void Debuff()
     {
-        if (buff != null && buff.IsBuffed)
+        if (buff != null)
         {
             buff.RemoveBuff();
         }

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -33,7 +33,8 @@ public class Combat : MonoBehaviour
     [SerializeField] private List<SerializedCombatAbility> combatAbilities;
     [SerializeField] private Health health;
     [SerializeField] private Buff buff;
-    
+    [SerializeField] private ConsumableResource resource;
+
     [Header("Knockback")]
 
     [SerializeField] private SurfaceDetector wallCollisionDetector;
@@ -59,6 +60,7 @@ public class Combat : MonoBehaviour
 
     public LayerMask AttackEffectLayer { get => attackEffectLayer; set => attackEffectLayer = value; }
     public Health Health { get => health; }
+    public ConsumableResource Resource { get => resource; }
 
     public SurfaceDetector WallCollisionDetector { get => wallCollisionDetector; }
     public float KnockbackSpeed { get => knockbackSpeed; }

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -152,6 +152,9 @@ public class Combat : MonoBehaviour
         movement.UpdateMovement(Vector2.zero);
         if (CombatStateMachine.CurrState is BlockState blockState)
         {
+            float blockCost = identifierToAbilityDictionary[CombatAbilityIdentifier.BLOCK].ResourceCost;
+            resource.Consume(blockCost);
+
             blockState.HandleHit(movement.IsFacingRight, ((Vector2)transform.position - new Vector2(attackerPosX, attackerPosY)).normalized);
         }
         else

--- a/Assets/Scripts/Actor Components/Combat/Combat.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat.cs
@@ -152,9 +152,6 @@ public class Combat : MonoBehaviour
         movement.UpdateMovement(Vector2.zero);
         if (CombatStateMachine.CurrState is BlockState blockState)
         {
-            float blockCost = identifierToAbilityDictionary[CombatAbilityIdentifier.BLOCK].ResourceCost;
-            resource.Consume(blockCost);
-
             blockState.HandleHit(movement.IsFacingRight, ((Vector2)transform.position - new Vector2(attackerPosX, attackerPosY)).normalized);
         }
         else

--- a/Assets/Scripts/Actor Components/ConsumableResource.cs
+++ b/Assets/Scripts/Actor Components/ConsumableResource.cs
@@ -1,0 +1,26 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ConsumableResource : MonoBehaviour
+{
+    [SerializeField] private float maxAmount;
+    [SerializeField] private Slider resourceBar;
+
+    private WaitForSeconds regenTick = new WaitForSeconds(0.1f);
+
+    public float CurrentAmount { get; private set; }
+    
+    private IEnumerator Regenerate()
+    {
+        yield return new WaitForSeconds(2);
+
+        while (CurrentAmount < maxAmount)
+        {
+            CurrentAmount += maxAmount / 100;
+            resourceBar.value = CurrentAmount / maxAmount;
+            yield return regenTick;
+        }
+    }
+}

--- a/Assets/Scripts/Actor Components/ConsumableResource.cs
+++ b/Assets/Scripts/Actor Components/ConsumableResource.cs
@@ -1,26 +1,66 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
+using UnityEngine.Events;
 using UnityEngine.UI;
+using Photon.Pun;
+
+[System.Serializable]
+public class ConsumeResourceEvent : UnityEvent<float> { }
 
 public class ConsumableResource : MonoBehaviour
 {
     [SerializeField] private float maxAmount;
-    [SerializeField] private Slider resourceBar;
+    [SerializeField] private UnityEvent regenerateResourceEvent;
+    [SerializeField] private ConsumeResourceEvent consumeResourceEvent;
+    [SerializeField] private PhotonView photonView;
 
-    private WaitForSeconds regenTick = new WaitForSeconds(0.1f);
+    private readonly float delayBeforeRegen = 1.5f;
+    private readonly WaitForSeconds regenTick = new WaitForSeconds(0.1f);
+
+    private Coroutine regen;
 
     public float CurrentAmount { get; private set; }
-    
+
+    public UnityEvent RegenerateResourceEvent { get => regenerateResourceEvent; }
+    public ConsumeResourceEvent ConsumeResourceEvent { get => consumeResourceEvent; }
+
+    private void Start()
+    {
+        CurrentAmount = maxAmount;
+    }
+
+    public bool CanConsume(float amount)
+    {
+        return CurrentAmount - amount >= 0;
+    }
+
+    public void Consume(float amount)
+    {
+        if (amount > 0)
+        {
+            if (regen != null)
+            {
+                StopCoroutine(regen);
+            }
+
+            regen = StartCoroutine(Regenerate());
+            CurrentAmount -= amount;
+            float currentFill = CurrentAmount / maxAmount;
+            consumeResourceEvent.Invoke(currentFill);
+        }
+    }
+
     private IEnumerator Regenerate()
     {
-        yield return new WaitForSeconds(2);
+        yield return new WaitForSeconds(delayBeforeRegen);
 
+        regenerateResourceEvent.Invoke();
         while (CurrentAmount < maxAmount)
         {
-            CurrentAmount += maxAmount / 100;
-            resourceBar.value = CurrentAmount / maxAmount;
+            CurrentAmount = Mathf.Min(maxAmount, CurrentAmount + maxAmount / 50);
             yield return regenTick;
         }
+        regen = null;
     }
 }

--- a/Assets/Scripts/Actor Components/ConsumableResource.cs
+++ b/Assets/Scripts/Actor Components/ConsumableResource.cs
@@ -47,7 +47,7 @@ public class ConsumableResource : MonoBehaviour
             }
 
             regen = StartCoroutine(Regenerate());
-            CurrentAmount -= amount;
+            CurrentAmount = Mathf.Max(CurrentAmount - amount, 0);
             float currentFill = CurrentAmount / maxAmount;
             updateResourceEvent.Invoke(currentFill);
         }

--- a/Assets/Scripts/Actor Components/ConsumableResource.cs.meta
+++ b/Assets/Scripts/Actor Components/ConsumableResource.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6b3eeb8de5d62be4c97b07611d0d6219
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -65,6 +65,9 @@ public class DragonPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.RemoveListener(healthUI.UpdateDragonHealthUI);
+            Combat.Resource.UpdateResourceEvent.RemoveListener(manaUI.UpdateManaUI);
+            Combat.Resource.RegenerateResourceEvent.RemoveListener(manaUI.RegenerateManaUI);
+            Combat.Resource.StopRegenResourceEvent.RemoveListener(manaUI.StopRegenManaUI);
         }
     }
 

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -15,6 +15,7 @@ public class DragonPlayerController : PlayerController
     private InputAction interactAction;
 
     private HealthUI healthUI;
+    private ConsumableResourceUI manaUI;
 
     private float horizontalMovementInput = 0f;
     private float verticalMovementInput = 0f;
@@ -31,7 +32,8 @@ public class DragonPlayerController : PlayerController
         dodgeAction = playerInput.actions["AirDodge"];
         interactAction = playerInput.actions["InteractAir"];
 
-        healthUI = GameObject.FindObjectOfType<HealthUI>();
+        healthUI = FindObjectOfType<HealthUI>();
+        manaUI = FindObjectOfType<ConsumableResourceUI>();
     }
 
     protected override void FixedUpdate()
@@ -50,6 +52,8 @@ public class DragonPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateDragonHealthUI);
+            Combat.Resource.ConsumeResourceEvent.AddListener(manaUI.UpdateManaUI);
+            Combat.Resource.RegenerateResourceEvent.AddListener(manaUI.RegenerateManaUI);
         }
     }
 

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -52,7 +52,7 @@ public class DragonPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateDragonHealthUI);
-            Combat.Resource.ConsumeResourceEvent.AddListener(manaUI.UpdateManaUI);
+            Combat.Resource.UpdateResourceEvent.AddListener(manaUI.UpdateManaUI);
             Combat.Resource.RegenerateResourceEvent.AddListener(manaUI.RegenerateManaUI);
         }
     }

--- a/Assets/Scripts/Input/DragonPlayerController.cs
+++ b/Assets/Scripts/Input/DragonPlayerController.cs
@@ -54,6 +54,7 @@ public class DragonPlayerController : PlayerController
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateDragonHealthUI);
             Combat.Resource.UpdateResourceEvent.AddListener(manaUI.UpdateManaUI);
             Combat.Resource.RegenerateResourceEvent.AddListener(manaUI.RegenerateManaUI);
+            Combat.Resource.StopRegenResourceEvent.AddListener(manaUI.StopRegenManaUI);
         }
     }
 

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -53,7 +53,7 @@ public class KnightPlayerController : PlayerController
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateKnightHealthUI);
             Combat.Resource.UpdateResourceEvent.AddListener(staminaUI.UpdateStaminaUI);
             Combat.Resource.RegenerateResourceEvent.AddListener(staminaUI.RegenerateStaminaUI);
-            Combat.Resource.StopRegenResourceEvent.AddListener(staminaUI.StopRegenManaUI);
+            Combat.Resource.StopRegenResourceEvent.AddListener(staminaUI.StopRegenStaminaUI);
         }
     }
 
@@ -64,6 +64,9 @@ public class KnightPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.RemoveListener(healthUI.UpdateKnightHealthUI);
+            Combat.Resource.UpdateResourceEvent.RemoveListener(staminaUI.UpdateStaminaUI);
+            Combat.Resource.RegenerateResourceEvent.RemoveListener(staminaUI.RegenerateStaminaUI);
+            Combat.Resource.StopRegenResourceEvent.RemoveListener(staminaUI.StopRegenStaminaUI);
         }
     }
 

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -51,7 +51,7 @@ public class KnightPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateKnightHealthUI);
-            Combat.Resource.ConsumeResourceEvent.AddListener(staminaUI.UpdateStaminaUI);
+            Combat.Resource.UpdateResourceEvent.AddListener(staminaUI.UpdateStaminaUI);
             Combat.Resource.RegenerateResourceEvent.AddListener(staminaUI.RegenerateStaminaUI);
         }
     }

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -15,6 +15,7 @@ public class KnightPlayerController : PlayerController
     private InputAction interactAction;
 
     private HealthUI healthUI;
+    private ConsumableResourceUI staminaUI;
 
     private float movementInput = 0f;
 
@@ -30,7 +31,8 @@ public class KnightPlayerController : PlayerController
         blockEndAction = playerInput.actions["BlockEnd"];
         interactAction = playerInput.actions["Interact"];
 
-        healthUI = GameObject.FindObjectOfType<HealthUI>();
+        healthUI = FindObjectOfType<HealthUI>();
+        staminaUI = FindObjectOfType<ConsumableResourceUI>();
     }
 
     protected override void FixedUpdate()
@@ -49,6 +51,8 @@ public class KnightPlayerController : PlayerController
         if (photonView.IsMine)
         {
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateKnightHealthUI);
+            Combat.Resource.ConsumeResourceEvent.AddListener(staminaUI.UpdateStaminaUI);
+            Combat.Resource.RegenerateResourceEvent.AddListener(staminaUI.RegenerateStaminaUI);
         }
     }
 

--- a/Assets/Scripts/Input/KnightPlayerController.cs
+++ b/Assets/Scripts/Input/KnightPlayerController.cs
@@ -53,6 +53,7 @@ public class KnightPlayerController : PlayerController
             Combat.Health.UpdateHealthEvent.AddListener(healthUI.UpdateKnightHealthUI);
             Combat.Resource.UpdateResourceEvent.AddListener(staminaUI.UpdateStaminaUI);
             Combat.Resource.RegenerateResourceEvent.AddListener(staminaUI.RegenerateStaminaUI);
+            Combat.Resource.StopRegenResourceEvent.AddListener(staminaUI.StopRegenManaUI);
         }
     }
 

--- a/Assets/Scripts/State Machine/States/Combat States/Attack States/MeleeAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/Attack States/MeleeAttackState.cs
@@ -7,10 +7,12 @@ namespace CombatStates
     public class MeleeAttackState : AttackState
     {
         private readonly AttackEffectArea attackEffectArea;
+        private readonly float attackCost;
 
-        public MeleeAttackState(Combat owner, AttackEffectArea attackEffectArea) : base(owner)
+        public MeleeAttackState(Combat owner, AttackEffectArea attackEffectArea, float attackCost) : base(owner)
         {
             this.attackEffectArea = attackEffectArea;
+            this.attackCost = attackCost;
         }
 
         public override void ExecuteAttackEffect()
@@ -20,6 +22,8 @@ namespace CombatStates
                 attackEffectArea.Size,
                 attackEffectArea.transform.eulerAngles.z,
                 owner.AttackEffectLayer);
+
+            owner.Resource.Consume(attackCost);
 
             foreach (Collider2D hit in hits)
             {

--- a/Assets/Scripts/State Machine/States/Combat States/Attack States/RangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/Attack States/RangedAttackState.cs
@@ -12,17 +12,20 @@ namespace CombatStates
         private readonly Vector2 attackDirection;
         private readonly LayerMask actorHitLayer;
         private RangedProjectileEvent fireRangedProjectileEvent;
+        private readonly float attackCost;
 
         public RangedAttackState(
             Combat owner, RangedProjectile projectilePrefab,
             Transform projectileOrigin, Vector2 attackDirection, LayerMask actorHitLayer,
-            RangedProjectileEvent fireRangedProjectileEvent) : base(owner)
+            RangedProjectileEvent fireRangedProjectileEvent,
+            float attackCost) : base(owner)
         {
             this.projectilePrefab = projectilePrefab;
             this.projectileOrigin = projectileOrigin;
             this.attackDirection = attackDirection.normalized;
             this.actorHitLayer = actorHitLayer;
             this.fireRangedProjectileEvent = fireRangedProjectileEvent;
+            this.attackCost = attackCost;
         }
 
         public override void Enter()
@@ -36,6 +39,8 @@ namespace CombatStates
 
         public override void ExecuteAttackEffect()
         {
+            owner.Resource.Consume(attackCost);
+
             RangedProjectile projectile = PhotonNetwork.Instantiate(
                 projectilePrefab.name,
                 projectileOrigin.position,

--- a/Assets/Scripts/State Machine/States/Combat States/BlockHitState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/BlockHitState.cs
@@ -10,6 +10,7 @@ namespace CombatStates
         private readonly float duration;
         private readonly BlockState.Direction direction;
         private readonly UnityEvent blockHitEvent;
+        private readonly float blockCost;
 
         private float startTime;
         private bool willReturnToBlock;

--- a/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/DeathState.cs
@@ -16,6 +16,7 @@ namespace CombatStates
             owner.CollisionLayer.SetLayer(LayerMask.NameToLayer("Dead"));
             owner.SpriteLayer.SetLayer(SpriteLayer.Layer.DEAD);
             owner.Animator.SetBool("isDead", true);
+            owner.Resource.EmptyAndStopRegen();
         }
 
         public override void Execute()

--- a/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
+++ b/Assets/Scripts/State Machine/States/Combat States/ReviveState.cs
@@ -13,6 +13,7 @@ namespace CombatStates
             owner.Health.SetMax();
             owner.SpriteLayer.ResetLayer();
             owner.Animator.SetBool("isReviving", true);
+            owner.Resource.Regenerate();
         }
 
         public override void Execute()

--- a/Assets/Scripts/UI/ConsumableResourceUI.cs
+++ b/Assets/Scripts/UI/ConsumableResourceUI.cs
@@ -1,0 +1,56 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+using Photon.Pun;
+
+public class ConsumableResourceUI : MonoBehaviour
+{
+    [SerializeField] private ResourceBar staminaBar;
+    [SerializeField] private ResourceBar manaBar;
+    [SerializeField] private PhotonView photonView;
+
+    public void UpdateStaminaUI(float currAmount)
+    {
+        photonView.RPC("RPC_UpdateStaminaUI", RpcTarget.All, currAmount);
+    }
+
+    public void UpdateManaUI(float currAmount)
+    {
+        photonView.RPC("RPC_UpdateManaUI", RpcTarget.All, currAmount);
+    }
+
+    public void RegenerateStaminaUI()
+    {
+        photonView.RPC("RPC_RegenerateStaminaUI", RpcTarget.All);
+    }
+
+    public void RegenerateManaUI()
+    {
+        photonView.RPC("RPC_RegenerateManaUI", RpcTarget.All);
+    }
+
+    [PunRPC]
+    private void RPC_UpdateStaminaUI(float currAmount)
+    {
+        staminaBar.UpdateValue(currAmount);
+    }
+
+    [PunRPC]
+    private void RPC_UpdateManaUI(float currAmount)
+    {
+        manaBar.UpdateValue(currAmount);
+    }
+
+    [PunRPC]
+    private void RPC_RegenerateStaminaUI()
+    {
+        staminaBar.StartRegeneration();
+    }
+
+    [PunRPC]
+    private void RPC_RegenerateManaUI()
+    {
+        manaBar.StartRegeneration();
+    }
+}

--- a/Assets/Scripts/UI/ConsumableResourceUI.cs
+++ b/Assets/Scripts/UI/ConsumableResourceUI.cs
@@ -1,7 +1,6 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using UnityEngine.UI;
 using Photon.Pun;
 
 public class ConsumableResourceUI : MonoBehaviour
@@ -20,14 +19,14 @@ public class ConsumableResourceUI : MonoBehaviour
         photonView.RPC("RPC_UpdateManaUI", RpcTarget.All, currAmount);
     }
 
-    public void RegenerateStaminaUI()
+    public void RegenerateStaminaUI(float regenSpeed)
     {
-        photonView.RPC("RPC_RegenerateStaminaUI", RpcTarget.All);
+        photonView.RPC("RPC_RegenerateStaminaUI", RpcTarget.All, regenSpeed);
     }
 
-    public void RegenerateManaUI()
+    public void RegenerateManaUI(float regenSpeed)
     {
-        photonView.RPC("RPC_RegenerateManaUI", RpcTarget.All);
+        photonView.RPC("RPC_RegenerateManaUI", RpcTarget.All, regenSpeed);
     }
 
     [PunRPC]
@@ -43,14 +42,14 @@ public class ConsumableResourceUI : MonoBehaviour
     }
 
     [PunRPC]
-    private void RPC_RegenerateStaminaUI()
+    private void RPC_RegenerateStaminaUI(float regenSpeed )
     {
-        staminaBar.StartRegeneration();
+        staminaBar.StartRegeneration(regenSpeed);
     }
 
     [PunRPC]
-    private void RPC_RegenerateManaUI()
+    private void RPC_RegenerateManaUI(float regenSpeed)
     {
-        manaBar.StartRegeneration();
+        manaBar.StartRegeneration(regenSpeed);
     }
 }

--- a/Assets/Scripts/UI/ConsumableResourceUI.cs
+++ b/Assets/Scripts/UI/ConsumableResourceUI.cs
@@ -29,6 +29,16 @@ public class ConsumableResourceUI : MonoBehaviour
         photonView.RPC("RPC_RegenerateManaUI", RpcTarget.All, regenSpeed);
     }
 
+    public void StopRegenStaminaUI()
+    {
+        photonView.RPC("RPC_StopRegenStaminaUI", RpcTarget.All);
+    }
+
+    public void StopRegenManaUI()
+    {
+        photonView.RPC("RPC_StopRegenManaUI", RpcTarget.All);
+    }
+
     [PunRPC]
     private void RPC_UpdateStaminaUI(float currAmount)
     {
@@ -51,5 +61,17 @@ public class ConsumableResourceUI : MonoBehaviour
     private void RPC_RegenerateManaUI(float regenSpeed)
     {
         manaBar.StartRegeneration(regenSpeed);
+    }
+
+    [PunRPC]
+    private void RPC_StopRegenStaminaUI()
+    {
+        staminaBar.StopRegeneration();
+    }
+
+    [PunRPC]
+    private void RPC_StopRegenManaUI()
+    {
+        manaBar.StopRegeneration();
     }
 }

--- a/Assets/Scripts/UI/ConsumableResourceUI.cs.meta
+++ b/Assets/Scripts/UI/ConsumableResourceUI.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 58f7fc17b21a38840b578c95c6df0fe2
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/ResourceBar.cs
+++ b/Assets/Scripts/UI/ResourceBar.cs
@@ -9,7 +9,6 @@ public class ResourceBar : MonoBehaviour
 
     private float maxValue = 1.0f;
     private Coroutine regen;
-    private WaitForSeconds regenTick = new WaitForSeconds(0.1f);
 
     private void Start()
     {
@@ -26,17 +25,18 @@ public class ResourceBar : MonoBehaviour
         slider.value = amount;
     }
 
-    public void StartRegeneration()
+    public void StartRegeneration(float regenSpeed )
     {
-        regen = StartCoroutine(Regenerate());
+        regen = StartCoroutine(Regenerate(regenSpeed));
     }
 
-    public IEnumerator Regenerate()
+    public IEnumerator Regenerate(float regenSpeed)
     {
         while (slider.value < maxValue)
         {
-            slider.value = Mathf.Min(maxValue, slider.value + maxValue / 50);
-            yield return regenTick;
+            slider.value = Mathf.Min(maxValue, 
+                slider.value + Time.deltaTime * regenSpeed);
+            yield return null;
         }
         regen = null;
     }

--- a/Assets/Scripts/UI/ResourceBar.cs
+++ b/Assets/Scripts/UI/ResourceBar.cs
@@ -30,6 +30,15 @@ public class ResourceBar : MonoBehaviour
         regen = StartCoroutine(Regenerate(regenSpeed));
     }
 
+    public void StopRegeneration()
+    {
+        if (regen != null)
+        {
+            StopCoroutine(regen);
+            regen = null;
+        }
+    }
+
     public IEnumerator Regenerate(float regenSpeed)
     {
         while (slider.value < maxValue)

--- a/Assets/Scripts/UI/ResourceBar.cs
+++ b/Assets/Scripts/UI/ResourceBar.cs
@@ -1,0 +1,43 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.UI;
+
+public class ResourceBar : MonoBehaviour
+{
+    [SerializeField] private Slider slider;
+
+    private float maxValue = 1.0f;
+    private Coroutine regen;
+    private WaitForSeconds regenTick = new WaitForSeconds(0.1f);
+
+    private void Start()
+    {
+        slider.value = maxValue;
+    }
+
+    public void UpdateValue(float amount)
+    {
+        if (regen != null)
+        {
+            StopCoroutine(regen);
+        }
+
+        slider.value = amount;
+    }
+
+    public void StartRegeneration()
+    {
+        regen = StartCoroutine(Regenerate());
+    }
+
+    public IEnumerator Regenerate()
+    {
+        while (slider.value < maxValue)
+        {
+            slider.value = Mathf.Min(maxValue, slider.value + maxValue / 50);
+            yield return regenTick;
+        }
+        regen = null;
+    }
+}

--- a/Assets/Scripts/UI/ResourceBar.cs.meta
+++ b/Assets/Scripts/UI/ResourceBar.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: ccae87fbc1df1e3469c3ac856cee896d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
Resolves #43 

Lets:
* Add resource bars to the in-game UI to represent the Knight's stamina level and Dragon's mana level.
* Add a ConsumableResource script to all actors. This script encapsulates the resource the actor uses, and the resource amount can be set in the Inspector.
* Add a resource cost to combat abilities. The cost for an ability can be set in the Inspector. An actor cannot execute an ability if they do not have enough resource to pay for the cost. If an ability should not cost any resource, the cost can be set to 0. (Particularly for enemies)
* Implement visual updates for the stamina and mana bars to reflect the players' stamina and mana levels respectively. When a player uses an ability, the resource will have a short delay before it will start regenerating. Executing another ability again will interrupt the regeneration.
* Change the timers in Buff and EscapeEvent to be coroutines instead.
* Disable mana regeneration for the Dragon when mounted.
* Set resource level to zero and disable resource regeneration when the player dies.
* Restart resource regeneration immediately when the player is revived. The resource level will start from zero.
* Add a stamina cost for blocking an attack as the Knight.

Things to consider: (in future PRs)
* ~~Disabling the mana regeneration for the Dragon when it is mounted. This will further balance the Dragon riding mechanic which may be too overpowered.~~
* Including resource costs for certain enemy abilities. Currently, all enemies do not have any resource pools and all their abilities have 0 cost.