### PR TITLE
Add blinking effect to signal ending of knight buff

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -93,6 +93,8 @@ MonoBehaviour:
   - RPC_UpdateStaminaUI
   - RPC_StopRegenManaUI
   - RPC_StopRegenStaminaUI
+  - RPC_ApplyBuffColor
+  - RPC_RemoveBuffColor
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -95,6 +95,7 @@ MonoBehaviour:
   - RPC_StopRegenStaminaUI
   - RPC_ApplyBuffColor
   - RPC_RemoveBuffColor
+  - RPC_StartBlinking
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -736,8 +736,6 @@ MonoBehaviour:
   buffDuration: 3
   spriteRenderer: {fileID: 7134467020418318920}
   buffedColor: {r: 0.09411766, g: 1, b: 1, a: 1}
-  blinkingDuration: 1
-  blinkingPeriod: 0.2
   photonView: {fileID: 5696632616774609759}
 --- !u!114 &5696632616774609759
 MonoBehaviour:

--- a/Assets/Resources/Knight.prefab
+++ b/Assets/Resources/Knight.prefab
@@ -736,6 +736,8 @@ MonoBehaviour:
   buffDuration: 3
   spriteRenderer: {fileID: 7134467020418318920}
   buffedColor: {r: 0.09411766, g: 1, b: 1, a: 1}
+  blinkingDuration: 1
+  blinkingPeriod: 0.2
   photonView: {fileID: 5696632616774609759}
 --- !u!114 &5696632616774609759
 MonoBehaviour:

--- a/Assets/Scripts/Actor Components/Buff.cs
+++ b/Assets/Scripts/Actor Components/Buff.cs
@@ -22,8 +22,8 @@ public class Buff : MonoBehaviour
     [SerializeField] private Color buffedColor;
     private Color defaultColor;
 
-    [SerializeField] private float blinkingDuration = 1.0f;
-    [SerializeField] private float blinkingPeriod = 0.2f;
+    private float blinkingDuration = 1.0f;
+    private float blinkingPeriod = 0.2f;
 
     [Space (10)]
 
@@ -49,9 +49,7 @@ public class Buff : MonoBehaviour
             if (buffTimeout != null)
             {
                 StopCoroutine(buffTimeout);
-                StopCoroutine(blinkingTime);
                 buffTimeout = null;
-                blinkingTime = null;
             }
         }
     }
@@ -105,6 +103,6 @@ public class Buff : MonoBehaviour
     [PunRPC]
     private void RPC_StartBlinking()
     {
-        blinkingTime = StartCoroutine(ExpireBlinking());
+        buffTimeout = StartCoroutine(ExpireBlinking());
     }
 }

--- a/Assets/Scripts/Actor Components/Buff.cs
+++ b/Assets/Scripts/Actor Components/Buff.cs
@@ -7,7 +7,6 @@ using Photon.Pun;
 public class Buff : MonoBehaviour
 {
     private Coroutine buffTimeout;
-    private Coroutine blinkingTime;
 
     [Header("Combat Changes")]
 

--- a/Assets/Scripts/Actor Components/Buff.cs
+++ b/Assets/Scripts/Actor Components/Buff.cs
@@ -22,7 +22,7 @@ public class Buff : MonoBehaviour
     private Color defaultColor;
 
     private float blinkingDuration = 1.0f;
-    private float blinkingPeriod = 0.17f;
+    private float blinkingPeriod = 0.2f;
 
     [Space (10)]
 


### PR DESCRIPTION
Modify ExpireBuff such that when time left before buff ends is equal to a given blinking duration, it switches the knight's colour in between the default and the buffed colours repeatedly to simulate blinking, the length of each blink being a given period. Knight prefab is modified to set these values.

Currently the blinking is hard coded to 1.0s with a period of 0.2s, so 5 blinks.

https://user-images.githubusercontent.com/77188160/159859937-c2be0342-7106-4886-b3d7-62373d286381.mov



