### PR TITLE
Add locks to CreateRoom and JoinRoom to prevent spamming

### DIFF
--- a/Assets/Scripts/Network/RoomCreator.cs
+++ b/Assets/Scripts/Network/RoomCreator.cs
@@ -13,6 +13,8 @@ public class RoomCreator : MonoBehaviourPunCallbacks
     [SerializeField] private string roomSceneName;
     [SerializeField] private TextMeshProUGUI errorMessage;
 
+    private bool isCreateOngoing;
+
     public void CreateRoom()
     {
         if (roomNameInputField.text == "")
@@ -21,22 +23,30 @@ public class RoomCreator : MonoBehaviourPunCallbacks
         }
         else
         {
-            Debug.Log($"Creating room ({roomNameInputField.text})");
+            if (!isCreateOngoing) {
+                isCreateOngoing = true;
+                Debug.Log($"Creating room ({roomNameInputField.text})");
 
-            RoomOptions roomOptions = new RoomOptions();
-            roomOptions.MaxPlayers = 2;
-            PhotonNetwork.CreateRoom(roomNameInputField.text, roomOptions, null);
+                RoomOptions roomOptions = new RoomOptions();
+                roomOptions.MaxPlayers = 2;
+                PhotonNetwork.CreateRoom(roomNameInputField.text, roomOptions, null);
+            } else {
+                Debug.Log($"Creating room ({roomNameInputField.text}) already in progress");
+            }
         }
     }
 
     public override void OnCreatedRoom()
     {
         base.OnCreatedRoom();
+        isCreateOngoing = false;
         LevelSelectManager.SetLevelsCleared(0);
     }
 
-    public override void OnCreateRoomFailed(short returnCode, string message) {
+    public override void OnCreateRoomFailed(short returnCode, string message) 
+    {
         base.OnCreateRoomFailed(returnCode, message);
+        isCreateOngoing = false;
         if (returnCode == LOBBY_ALREADY_EXISTS_ERROR_NAME) {
             errorMessage.text = "A lobby with that name already exists!";
         }

--- a/Assets/Scripts/Network/RoomCreator.cs
+++ b/Assets/Scripts/Network/RoomCreator.cs
@@ -17,23 +17,19 @@ public class RoomCreator : MonoBehaviourPunCallbacks
 
     public void CreateRoom()
     {
-        if (roomNameInputField.text == "")
-        {
+        if (roomNameInputField.text == "") {
             errorMessage.text = "Please enter a room name.";
-        }
-        else
-        {
-            if (!isCreateOngoing) {
-                isCreateOngoing = true;
-                Debug.Log($"Creating room ({roomNameInputField.text})");
+        } else if (!isCreateOngoing) {
+            isCreateOngoing = true;
+            Debug.Log($"Creating room ({roomNameInputField.text})");
 
-                RoomOptions roomOptions = new RoomOptions();
-                roomOptions.MaxPlayers = 2;
-                PhotonNetwork.CreateRoom(roomNameInputField.text, roomOptions, null);
-            } else {
-                Debug.Log($"Creating room ({roomNameInputField.text}) already in progress");
-            }
+            RoomOptions roomOptions = new RoomOptions();
+            roomOptions.MaxPlayers = 2;
+            PhotonNetwork.CreateRoom(roomNameInputField.text, roomOptions, null);
+        } else {
+            Debug.Log($"Creating room ({roomNameInputField.text}) already in progress");
         }
+        
     }
 
     public override void OnCreatedRoom()

--- a/Assets/Scripts/Network/RoomJoiner.cs
+++ b/Assets/Scripts/Network/RoomJoiner.cs
@@ -18,19 +18,16 @@ public class RoomJoiner : MonoBehaviourPunCallbacks
 
     public void JoinRoom()
     {
-        if (roomNameInputField.text=="")
-        {
+        if (roomNameInputField.text=="") {
             errorMessage.text = "Please enter a room name.";
-        } else
-        {
-            if (!isJoinOngoing) {
-                isJoinOngoing = true;
-                Debug.Log($"Joining room ({roomNameInputField.text})");
-                PhotonNetwork.JoinRoom(roomNameInputField.text);
-            } else {
-                Debug.Log($"Joining room ({roomNameInputField.text}) already in progress");
-            }
+        } else if (!isJoinOngoing) {
+            isJoinOngoing = true;
+            Debug.Log($"Joining room ({roomNameInputField.text})");
+            PhotonNetwork.JoinRoom(roomNameInputField.text);
+        } else {
+            Debug.Log($"Joining room ({roomNameInputField.text}) already in progress");
         }
+    
     }
 
     public override void OnJoinedRoom()

--- a/Assets/Scripts/Network/RoomJoiner.cs
+++ b/Assets/Scripts/Network/RoomJoiner.cs
@@ -14,6 +14,8 @@ public class RoomJoiner : MonoBehaviourPunCallbacks
     [SerializeField] private string roomSceneName;
     [SerializeField] private TextMeshProUGUI errorMessage;
 
+    private bool isJoinOngoing;
+
     public void JoinRoom()
     {
         if (roomNameInputField.text=="")
@@ -21,18 +23,26 @@ public class RoomJoiner : MonoBehaviourPunCallbacks
             errorMessage.text = "Please enter a room name.";
         } else
         {
-            Debug.Log($"Joining room ({roomNameInputField.text})");
-            PhotonNetwork.JoinRoom(roomNameInputField.text);
+            if (!isJoinOngoing) {
+                isJoinOngoing = true;
+                Debug.Log($"Joining room ({roomNameInputField.text})");
+                PhotonNetwork.JoinRoom(roomNameInputField.text);
+            } else {
+                Debug.Log($"Joining room ({roomNameInputField.text}) already in progress");
+            }
         }
     }
 
     public override void OnJoinedRoom()
     {
+        isJoinOngoing = false;
         PhotonNetwork.LoadLevel(roomSceneName);
     }
 
-    public override void OnJoinRoomFailed(short returnCode, string message) {
+    public override void OnJoinRoomFailed(short returnCode, string message) 
+    {
         base.OnJoinRoomFailed(returnCode, message);
+        isJoinOngoing = false;
         if (returnCode == LOBBY_DOES_NOT_EXIST_ERROR_NAME) {
             errorMessage.text = "A lobby with that name does not exist!";
         } else if (returnCode == LOBBY_FULL_ERROR_NAME) {


### PR DESCRIPTION
Currently spamming the Create or Join button in Lobby throws errors since the client attempts to create/join room while another process is already ongoing.

Add locks so when PhotonNetwork.CreateRoom or PhotonNetwork.JoinRoom are called, they cannot be called again until OnCreatedRoom/OnJoinedRoom or OnCreateRoomFailed/OnJoinRoomFailed are called.