### PR TITLE
Buff dragon and ranged knight enemy values

### DIFF
--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -968,8 +968,8 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isEnabled: 1
   resourceCost: 15
-  speed: 20
-  distance: 4
+  speed: 40
+  distance: 8
 --- !u!1 &8714695237697900579
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -538,6 +538,9 @@ MonoBehaviour:
   isDefaultFacingRight: 1
   defaultStoppingDistanceFromNavTargets: 1.4
   navFastDistanceThreshold: 8
+  flipDirectionEvent:
+    m_PersistentCalls:
+      m_Calls: []
   movementSpeed: 2
 --- !u!114 &1860061280274303189
 MonoBehaviour:
@@ -579,7 +582,10 @@ MonoBehaviour:
   deathEvent:
     m_PersistentCalls:
       m_Calls: []
-  reviveEvent:
+  reviveStartEvent:
+    m_PersistentCalls:
+      m_Calls: []
+  reviveFinishEvent:
     m_PersistentCalls:
       m_Calls: []
 --- !u!114 &4948305080866607028
@@ -755,7 +761,7 @@ MonoBehaviour:
   m_EditorClassIdentifier: 
   isEnabled: 1
   resourceCost: 0
-  maxRange: 5
+  maxRange: 10
   readyDuration: 4
   timeToLock: 3
   projectilePrefab: {fileID: 2451902509671687090, guid: d75a65ad664c7a147bf5869d211fbe95, type: 3}


### PR DESCRIPTION
- Distance covered by dragon's dodge has been increased
- Ranged knight enemy's max range has been increased
  - This fixes a bug where if the knight was far enough above or below the ranged knight enemy, the ranged knight enemy would get lost and flip left and right repeatedly due to its inability to traverse the Y axis. This is more of a temporary fix that will break if levels ever get any taller. An actual fix will come in a future pull request that implements pathfinding.