### PR TITLE
Fix blinking bug

### DIFF
--- a/Assets/Scripts/Actor Components/Buff.cs
+++ b/Assets/Scripts/Actor Components/Buff.cs
@@ -48,6 +48,7 @@ public class Buff : MonoBehaviour
             if (buffTimeout != null)
             {
                 StopCoroutine(buffTimeout);
+                IsBuffed = false;
                 buffTimeout = null;
             }
         }
@@ -61,7 +62,7 @@ public class Buff : MonoBehaviour
     private IEnumerator ExpireBuff() 
     {
         yield return new WaitForSeconds(Math.Max(0, buffDuration - blinkingDuration));
-        StartBlinking();
+        if (IsBuffed) StartBlinking();
     }
 
     private IEnumerator ExpireBlinking()
@@ -72,8 +73,15 @@ public class Buff : MonoBehaviour
         while (counter < numOfBlinks) {
             spriteRenderer.color = defaultColor;
             yield return new WaitForSeconds(blinkingPeriod / 2);
+            if (!IsBuffed) break;
+
             spriteRenderer.color = buffedColor;
             yield return new WaitForSeconds(blinkingPeriod / 2);
+            if (!IsBuffed) {
+                spriteRenderer.color = defaultColor;
+                break;
+            }
+
             counter++;
         }
 


### PR DESCRIPTION
When knight buff is ended prematurely (eg. used on enemy), the blinking effect still occurs. This is because if StopCoroutine is called while ExpireBuff's WaitForSeconds is in progress, StartBlinking() is still called. To fix this, add condition such that if RemoveBuff() is called before blinking starts, blinking does not start.

This can also occur while blinking is in progress (because the blinking logic also has WaitForSeconds calls). So we also add conditions to check if RemoveBuff() has been called during blinking, and if so end the blinking and set the knight sprite color to default.