### PR TITLE
Set up audio management system

### DIFF
--- a/Assets/Main.mixer
+++ b/Assets/Main.mixer
@@ -1,0 +1,140 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!244 &-6971690524706248011
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: a820fee7215e9fa43bd8ee17eb040571
+  m_EffectName: Attenuation
+  m_MixLevel: a79ccc32b37464e4ab017089d1dc044e
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!244 &-1378381397115244835
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: 188fa010c525f1b4ba840e1da0518f8f
+  m_EffectName: Attenuation
+  m_MixLevel: e2255b67becdd864dab6416789bfd7a5
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!241 &24100000
+AudioMixerController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Main
+  m_OutputGroup: {fileID: 0}
+  m_MasterGroup: {fileID: 24300002}
+  m_Snapshots:
+  - {fileID: 24500006}
+  m_StartSnapshot: {fileID: 24500006}
+  m_SuspendThreshold: -80
+  m_EnableSuspend: 1
+  m_UpdateMode: 0
+  m_ExposedParameters:
+  - guid: 060170d02040d79438ea7a0a9cb562a8
+    name: MasterVolume
+  m_AudioMixerGroupViews:
+  - guids:
+    - 143047439a4918d448dccf3ee333b3a9
+    - 0d07e11e513be5547b0c213a52d4e229
+    - 1c810fa6ce9164244820d96292840ad3
+    name: View
+  m_CurrentViewIndex: 0
+  m_TargetSnapshot: {fileID: 24500006}
+--- !u!243 &24300002
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Master
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: 143047439a4918d448dccf3ee333b3a9
+  m_Children:
+  - {fileID: 7196020780452657341}
+  - {fileID: 9131962080079578087}
+  m_Volume: 060170d02040d79438ea7a0a9cb562a8
+  m_Pitch: 5610df2b19e15e24b9fff04f87e7d431
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: 24400004}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0
+--- !u!244 &24400004
+AudioMixerEffectController:
+  m_ObjectHideFlags: 3
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_EffectID: c9f466c6c0ea3e8488866ef3e558a5fc
+  m_EffectName: Attenuation
+  m_MixLevel: 54654021a7a81964a90506207d6cec0f
+  m_Parameters: []
+  m_SendTarget: {fileID: 0}
+  m_EnableWetMix: 0
+  m_Bypass: 0
+--- !u!245 &24500006
+AudioMixerSnapshotController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Snapshot
+  m_AudioMixer: {fileID: 24100000}
+  m_SnapshotID: e452e71d4b65850478233c0259b26ad7
+  m_FloatValues: {}
+  m_TransitionOverrides: {}
+--- !u!243 &7196020780452657341
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: SFX
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: 0d07e11e513be5547b0c213a52d4e229
+  m_Children: []
+  m_Volume: 9fd036a9fd237c44e820c9f8fd48836c
+  m_Pitch: 4c88b75a7be7c1b499bc6e8c690ee174
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: -1378381397115244835}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0
+--- !u!243 &9131962080079578087
+AudioMixerGroupController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Music
+  m_AudioMixer: {fileID: 24100000}
+  m_GroupID: 1c810fa6ce9164244820d96292840ad3
+  m_Children: []
+  m_Volume: efdf10ea11bd33949b440489bf7a3dd1
+  m_Pitch: 9bafe19c64fbc5d4da9ae4cf2be17ae2
+  m_Send: 00000000000000000000000000000000
+  m_Effects:
+  - {fileID: -6971690524706248011}
+  m_UserColorIndex: 0
+  m_Mute: 0
+  m_Solo: 0
+  m_BypassEffects: 0

--- a/Assets/Main.mixer.meta
+++ b/Assets/Main.mixer.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 13cf87b401c663b41a7775fba705b2a5
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 24100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -97,6 +97,12 @@ MonoBehaviour:
   - RPC_ApplyBuffColor
   - RPC_RemoveBuffColor
   - RPC_StartBlinking
+  - RPC_SetAudioVolume
+  - RPC_PauseMusic
+  - RPC_PlayMusic
+  - RPC_PlaySoundFx
+  - RPC_StopMusic
+  - RPC_StopSoundFx
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Prefabs/Audio.meta
+++ b/Assets/Prefabs/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 1be7d32906a180849b5d8654c34cb2ff
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Audio/Audio Manager.prefab
+++ b/Assets/Prefabs/Audio/Audio Manager.prefab
@@ -10,6 +10,8 @@ GameObject:
   m_Component:
   - component: {fileID: 2081068685261307423}
   - component: {fileID: 2081068685261307422}
+  - component: {fileID: 2460436164896918737}
+  - component: {fileID: 5304730455530151049}
   m_Layer: 0
   m_Name: Audio Manager
   m_TagString: Untagged
@@ -49,3 +51,38 @@ MonoBehaviour:
   musicGroup: {fileID: 9131962080079578087, guid: 13cf87b401c663b41a7775fba705b2a5, type: 2}
   soundFxs: []
   musicTracks: []
+--- !u!114 &2460436164896918737
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081068685261307416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 328679966f82008409c411f25248ed66, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 5304730455530151049}
+--- !u!114 &5304730455530151049
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081068685261307416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0

--- a/Assets/Prefabs/Audio/Audio Manager.prefab
+++ b/Assets/Prefabs/Audio/Audio Manager.prefab
@@ -1,0 +1,51 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1 &2081068685261307416
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2081068685261307423}
+  - component: {fileID: 2081068685261307422}
+  m_Layer: 0
+  m_Name: Audio Manager
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &2081068685261307423
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081068685261307416}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 0}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2081068685261307422
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2081068685261307416}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9bb9fd62af3f10c4ea5115dc206e4963, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  mainMix: {fileID: 24100000, guid: 13cf87b401c663b41a7775fba705b2a5, type: 2}
+  mainMixVolumeParam: MasterVolume
+  sfxGroup: {fileID: 7196020780452657341, guid: 13cf87b401c663b41a7775fba705b2a5, type: 2}
+  musicGroup: {fileID: 9131962080079578087, guid: 13cf87b401c663b41a7775fba705b2a5, type: 2}
+  soundFxs: []
+  musicTracks: []

--- a/Assets/Prefabs/Audio/Audio Manager.prefab.meta
+++ b/Assets/Prefabs/Audio/Audio Manager.prefab.meta
@@ -1,0 +1,7 @@
+fileFormatVersion: 2
+guid: fd53fcba92972e441a68132e6ba3b4b9
+PrefabImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scenes/Test.unity
+++ b/Assets/Scenes/Test.unity
@@ -1004,6 +1004,11 @@ Transform:
   m_CorrespondingSourceObject: {fileID: 1615772436983265034, guid: cb90c19427240a64d817be154885b4eb, type: 3}
   m_PrefabInstance: {fileID: 186633286}
   m_PrefabAsset: {fileID: 0}
+--- !u!4 &189221692 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+  m_PrefabInstance: {fileID: 2081068685114946851}
+  m_PrefabAsset: {fileID: 0}
 --- !u!1 &196844492
 GameObject:
   m_ObjectHideFlags: 0
@@ -2126,7 +2131,8 @@ Transform:
   m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children: []
+  m_Children:
+  - {fileID: 189221692}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -4318,3 +4324,60 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   slider: {fileID: 2068160358}
+--- !u!1001 &2081068685114946851
+PrefabInstance:
+  m_ObjectHideFlags: 0
+  serializedVersion: 2
+  m_Modification:
+    m_TransformParent: {fileID: 765560305}
+    m_Modifications:
+    - target: {fileID: 2081068685261307416, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_Name
+      value: Audio Manager
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_RootOrder
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalPosition.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalPosition.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalPosition.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalRotation.w
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalRotation.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalRotation.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalRotation.z
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.x
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.y
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 2081068685261307423, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}
+      propertyPath: m_LocalEulerAnglesHint.z
+      value: 0
+      objectReference: {fileID: 0}
+    m_RemovedComponents: []
+  m_SourcePrefab: {fileID: 100100000, guid: fd53fcba92972e441a68132e6ba3b4b9, type: 3}

--- a/Assets/Scripts/Audio.meta
+++ b/Assets/Scripts/Audio.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 27857d1aeeafbf648b83ef1ee8522258
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -1,0 +1,245 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using UnityEngine.Events;
+using UnityEngine.Audio;
+
+public class AudioManager : MonoBehaviour
+{
+    public static readonly float MAIN_VOLUME_MIN = -80f;
+    public static readonly float MAIN_VOLUME_MAX = 0f;
+
+    private static AudioManager _instance;
+    public static AudioManager Instance { get => _instance; }
+
+    [SerializeField] private AudioMixer mainMix;
+    [SerializeField] private string mainMixVolumeParam = "MasterVolume";
+
+    [Space(10)]
+
+    [SerializeField] private AudioMixerGroup sfxGroup;
+    [SerializeField] private AudioMixerGroup musicGroup;
+
+    [Space(10)]
+
+    [SerializeField] private SoundFx[] soundFxs;
+    [SerializeField] private Music[] musicTracks;
+
+    private Dictionary<string, SoundFx> nameToFxDictionary;
+    private Dictionary<string, Music> nameToMusicDictionary;
+
+    void Awake()
+    {
+        // singleton
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            _instance = this;
+        }
+
+        nameToFxDictionary = new Dictionary<string, SoundFx>();
+        foreach (SoundFx soundFx in soundFxs)
+        {
+            AudioSource audioSource = gameObject.AddComponent<AudioSource>();
+            audioSource.outputAudioMixerGroup = sfxGroup;
+            soundFx.InitialiseSound(audioSource);
+            nameToFxDictionary[soundFx.Name] = soundFx;
+        }
+
+        nameToMusicDictionary = new Dictionary<string, Music>();
+        foreach (Music music in musicTracks)
+        {
+            AudioSource audioSource = gameObject.AddComponent<AudioSource>();
+            audioSource.outputAudioMixerGroup = musicGroup;
+            music.InitialiseSound(audioSource);
+            nameToMusicDictionary[music.Name] = music;
+        }
+    }
+
+    #region Public Methods
+    /// <summary>
+    /// Sets the volume of the main mix to the given volume.
+    /// </summary>
+    /// <param name="toVolume">The target volume.</param>
+    /// <param name="doFade">Whether to fade towards the target volume.</param>
+    /// <param name="fadeLength">Duration of the fade. Only applicable if <c>doFade</c> is <c>true</c>.</param>
+    public void SetAudioVolume(float toVolume, bool doFade = false, float fadeLength = 3f)
+    {
+        if (!doFade)
+        {
+            mainMix.SetFloat(mainMixVolumeParam, toVolume);
+        }
+        else
+        {
+            StartCoroutine(FadeAllAudio(toVolume, fadeLength));
+        }
+    }
+
+    /// <summary>
+    /// Plays the sound FX with the given name.
+    /// </summary>
+    /// <param name="name">The name of the sound FX to play.</param>
+    /// <param name="doFade">If true, fades the sound FX in. Else, it starts at default volume.</param>
+    /// <param name="fadeTime">The length of the fade in.</param>
+    public void PlaySoundFx(string name, bool doFade = false, float fadeTime = 1f)
+    {
+        if (!nameToFxDictionary.ContainsKey(name))
+        {
+            Debug.LogError($"SoundFx [{name}] not found in AudioManager.");
+            return;
+        }
+
+        SoundFx soundFx = nameToFxDictionary[name];
+        soundFx.Play();
+
+        if (doFade)
+        {
+            StartCoroutine(FadeSound(soundFx, 0, soundFx.DefaultVolume, fadeTime));
+        }
+        else
+        {
+            soundFx.Volume = soundFx.DefaultVolume;
+        }
+    }
+
+    /// <summary>
+    /// Stops the sound FX with the given name.
+    /// </summary>
+    /// <param name="name">The name of the sound FX to stop.</param>
+    /// <param name="doFade">If true, fades the sound FX out before stopping. Else, it simply stops.</param>
+    /// <param name="fadeTime">The length of the fade out.</param>
+    public void StopSoundFx(string name, bool doFade = false, float fadeTime = 1f)
+    {
+        if (!nameToFxDictionary.ContainsKey(name))
+        {
+            Debug.LogError($"SoundFx [{name}] not found in AudioManager.");
+            return;
+        }
+
+        SoundFx soundFx = nameToFxDictionary[name];
+        if (doFade)
+        {
+            StartCoroutine(FadeSound(soundFx, soundFx.Volume, 0, fadeTime, soundFx.Stop));
+        }
+        else
+        {
+            soundFx.Stop();
+        }
+    }
+
+    /// <summary>
+    /// Plays the music with the given name.
+    /// </summary>
+    /// <param name="name">The name of the music to play.</param>
+    /// <param name="doFade">If true, fades the music in. Else, music starts at default volume.</param>
+    /// <param name="fadeTime">The length of the fade in.</param>
+    public void PlayMusic(string name, bool doFade = false, float fadeTime = 1f)
+    {
+        if (!nameToMusicDictionary.ContainsKey(name))
+        {
+            Debug.LogError($"Music [{name}] not found in AudioManager.");
+            return;
+        }
+
+        Music music = nameToMusicDictionary[name];
+        music.Play();
+
+        if (doFade)
+        {
+            StartCoroutine(FadeSound(music, 0, music.DefaultVolume, fadeTime));
+        }
+        else
+        {
+            music.Volume = music.DefaultVolume;
+        }
+    }
+
+    /// <summary>
+    /// Pauses the given music.
+    /// </summary>
+    /// <param name="music">The music to pause.</param>
+    /// <param name="doFade">If true, fades the music out before pausing. Else, music simply pauses.</param>
+    /// <param name="fadeTime">The length of the fade out.</param>
+    public void PauseMusic(Music music, bool doFade = false, float fadeTime = 1f)
+    {
+        if (doFade)
+        {
+            StartCoroutine(FadeSound(music, music.Volume, 0, fadeTime, () => PauseMusic(music)));
+        }
+        else
+        {
+            music.Pause();
+        }
+    }
+
+    /// <summary>
+    /// Stops the given music.
+    /// </summary>
+    /// <param name="music">The music to stop.</param>
+    /// <param name="doFade">If true, fades the music out before stopping. Else, music simply stops.</param>
+    /// <param name="fadeTime">The length of the fade out.</param>
+    public void StopMusic(Music music, bool doFade = false, float fadeTime = 1f)
+    {
+        if (doFade)
+        {
+            StartCoroutine(FadeSound(music, music.Volume, 0, fadeTime, music.Stop));
+        }
+        else
+        {
+            music.Stop();
+        }
+    }
+    #endregion
+
+    #region Private Methods
+    /// <summary>
+    /// Fades all audio from the current mix volume to the given volume.
+    /// </summary>
+    /// <param name="toVolume">The target volume in decibels.</param>
+    /// <param name="fadeLength">The length of the fade.</param>
+    /// <returns>IEnumerator; this is a coroutine.</returns>
+    private IEnumerator FadeAllAudio(float toVolume, float fadeLength)
+    {
+        mainMix.GetFloat(mainMixVolumeParam, out float fromVolume);
+
+        float elapsedTime = 0f;
+        while (elapsedTime < fadeLength)
+        {
+            // linear volume change
+            mainMix.SetFloat(mainMixVolumeParam, Mathf.Lerp(fromVolume, toVolume, elapsedTime / fadeLength));
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+
+        mainMix.SetFloat(mainMixVolumeParam, toVolume);
+    }
+
+    /// <summary>
+    /// Fades the volume of the given sound between the two given volume levels.
+    /// </summary>
+    /// <param name="sound">The sound whose volume to fade.</param>
+    /// <param name="fromVolume">The volume from which to start.</param>
+    /// <param name="toVolume">The target volume.</param>
+    /// <param name="fadeLength">The duration of the fade.</param>
+    /// <param name="endCallback">A callback that is invoked after the fade is complete.</param>
+    /// <returns>IEnumerator; this is a coroutine.</returns>
+    private IEnumerator FadeSound(Sound sound, float fromVolume, float toVolume, float fadeLength, UnityAction endCallback = null)
+    {
+        sound.Volume = fromVolume;
+
+        float elapsedTime = 0f;
+        while (elapsedTime < fadeLength)
+        {
+            sound.Volume = Mathf.Lerp(fromVolume, toVolume, elapsedTime);
+            elapsedTime += Time.deltaTime;
+            yield return null;
+        }
+
+        sound.Volume = toVolume;
+        endCallback?.Invoke();
+    }
+    #endregion
+}

--- a/Assets/Scripts/Audio/AudioManager.cs
+++ b/Assets/Scripts/Audio/AudioManager.cs
@@ -59,7 +59,7 @@ public class AudioManager : MonoBehaviour
         }
     }
 
-    #region Public Methods
+    #region Public Methods - Audio
     /// <summary>
     /// Sets the volume of the main mix to the given volume.
     /// </summary>
@@ -77,7 +77,9 @@ public class AudioManager : MonoBehaviour
             StartCoroutine(FadeAllAudio(toVolume, fadeLength));
         }
     }
+    #endregion
 
+    #region Public Methods - SFX
     /// <summary>
     /// Plays the sound FX with the given name.
     /// </summary>
@@ -129,7 +131,9 @@ public class AudioManager : MonoBehaviour
             soundFx.Stop();
         }
     }
+    #endregion
 
+    #region Public Methods - Music
     /// <summary>
     /// Plays the music with the given name.
     /// </summary>

--- a/Assets/Scripts/Audio/AudioManager.cs.meta
+++ b/Assets/Scripts/Audio/AudioManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 9bb9fd62af3f10c4ea5115dc206e4963
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Audio/AudioManagerSynced.cs
+++ b/Assets/Scripts/Audio/AudioManagerSynced.cs
@@ -1,0 +1,127 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class AudioManagerSynced : MonoBehaviour
+{
+    private static AudioManagerSynced _instance;
+    public static AudioManagerSynced Instance { get => _instance; }
+
+    [SerializeField] private PhotonView photonView;
+
+    private void Awake()
+    {
+        // singleton
+        if (_instance != null && _instance != this)
+        {
+            Destroy(gameObject);
+        }
+        else
+        {
+            _instance = this;
+        }
+    }
+
+    /// <summary>
+    /// Sets the volume of the main mix to the given volume.
+    /// </summary>
+    /// <param name="toVolume">The target volume.</param>
+    /// <param name="doFade">Whether to fade towards the target volume.</param>
+    /// <param name="fadeLength">Duration of the fade. Only applicable if <c>doFade</c> is <c>true</c>.</param>
+    public void SetAudioVolume(float toVolume, bool doFade = false, float fadeLength = 3f)
+    {
+        photonView.RPC("RPC_SetAudioVolume", RpcTarget.All, toVolume, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_SetAudioVolume(float toVolume, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.SetAudioVolume(toVolume, doFade, fadeLength);
+    }
+
+    /// <summary>
+    /// Plays the sound FX with the given name.
+    /// </summary>
+    /// <param name="index">The index of the sound FX to play.</param>
+    /// <param name="doFade">If true, fades the sound FX in. Else, it starts at default volume.</param>
+    /// <param name="fadeLength">The length of the fade in.</param>
+    public void PlaySoundFx(SoundFx.LibraryIndex index, bool doFade = false, float fadeLength = 1f)
+    {
+        photonView.RPC("RPC_PlaySoundFx", RpcTarget.All, (byte)index, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_PlaySoundFx(byte index, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.PlaySoundFx((SoundFx.LibraryIndex)index, doFade, fadeLength);
+    }
+
+    /// <summary>
+    /// Stops the sound FX with the given name.
+    /// </summary>
+    /// <param name="index">The index of the sound FX to stop.</param>
+    /// <param name="doFade">If true, fades the sound FX out before stopping. Else, it simply stops.</param>
+    /// <param name="fadeLength">The length of the fade out.</param>
+    public void StopSoundFx(SoundFx.LibraryIndex index, bool doFade = false, float fadeLength = 1f)
+    {
+        photonView.RPC("RPC_StopSoundFx", RpcTarget.All, (byte)index, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_StopSoundFx(byte index, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.StopSoundFx((SoundFx.LibraryIndex)index, doFade, fadeLength);
+    }
+
+    /// <summary>
+    /// Plays the music with the given name.
+    /// </summary>
+    /// <param name="index">The index of the music to play.</param>
+    /// <param name="doFade">If true, fades the music in. Else, music starts at default volume.</param>
+    /// <param name="fadeLength">The length of the fade in.</param>
+    public void PlayMusic(Music.LibraryIndex index, bool doFade = false, float fadeLength = 1f)
+    {
+        photonView.RPC("RPC_PlayMusic", RpcTarget.All, (byte)index, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_PlayMusic(byte index, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.PlayMusic((Music.LibraryIndex)index, doFade, fadeLength);
+    }
+
+    /// <summary>
+    /// Pauses the given music.
+    /// </summary>
+    /// <param name="index">The index of the music to pause.</param>
+    /// <param name="doFade">If true, fades the music out before pausing. Else, music simply pauses.</param>
+    /// <param name="fadeLength">The length of the fade out.</param>
+    public void PauseMusic(Music.LibraryIndex index, bool doFade = false, float fadeLength = 1f)
+    {
+        photonView.RPC("RPC_PauseMusic", RpcTarget.All, (byte)index, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_PauseMusic(byte index, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.PauseMusic((Music.LibraryIndex)index, doFade, fadeLength);
+    }
+
+    /// <summary>
+    /// Stops the given music.
+    /// </summary>
+    /// <param name="index">The index of the music to stop.</param>
+    /// <param name="doFade">If true, fades the music out before stopping. Else, music simply stops.</param>
+    /// <param name="fadeLength">The length of the fade out.</param>
+    public void StopMusic(Music.LibraryIndex index, bool doFade = false, float fadeLength = 1f)
+    {
+        photonView.RPC("RPC_StopMusic", RpcTarget.All, (byte)index, doFade, fadeLength);
+    }
+
+    [PunRPC]
+    private void RPC_StopMusic(byte index, bool doFade, float fadeLength)
+    {
+        AudioManager.Instance.StopMusic((Music.LibraryIndex)index, doFade, fadeLength);
+    }
+}

--- a/Assets/Scripts/Audio/AudioManagerSynced.cs.meta
+++ b/Assets/Scripts/Audio/AudioManagerSynced.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 328679966f82008409c411f25248ed66
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Audio/Music.cs
+++ b/Assets/Scripts/Audio/Music.cs
@@ -1,0 +1,27 @@
+using UnityEngine;
+
+[System.Serializable]
+public class Music : Sound
+{
+    [SerializeField] private AudioClip audioClip;
+
+    /// <summary>
+    /// Sets the sound's audio source to the given AudioSource.
+    /// Also sets the source's volume and loop setting to the sound's default volume and loop setting.
+    /// </summary>
+    /// <remarks>The source's audio clip is set to the music's audio clip.</remarks>
+    /// <param name="audioSource">The AudioSource to set this sound's audio source to.</param>
+    public override void InitialiseSound(AudioSource audioSource)
+    {
+        audioSource.clip = audioClip;
+        base.InitialiseSound(audioSource);
+    }
+
+    /// <summary>
+    /// Plays the music.
+    /// </summary>
+    public override void Play()
+    {
+        audioSource.Play();
+    }
+}

--- a/Assets/Scripts/Audio/Music.cs
+++ b/Assets/Scripts/Audio/Music.cs
@@ -3,7 +3,17 @@ using UnityEngine;
 [System.Serializable]
 public class Music : Sound
 {
+    public enum LibraryIndex
+    {
+        MENU
+    }
+
+    [Space(10)]
+
+    [SerializeField] private LibraryIndex libraryIndex;
     [SerializeField] private AudioClip audioClip;
+
+    public LibraryIndex Index { get => libraryIndex; }
 
     /// <summary>
     /// Sets the sound's audio source to the given AudioSource.

--- a/Assets/Scripts/Audio/Music.cs.meta
+++ b/Assets/Scripts/Audio/Music.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 83c4862155481a1498175a06ba70475d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Audio/Sound.cs
+++ b/Assets/Scripts/Audio/Sound.cs
@@ -1,0 +1,49 @@
+using UnityEngine;
+
+public abstract class Sound
+{
+    protected AudioSource audioSource;
+
+    [SerializeField] protected string name;
+    [Range(0, 1)]
+    [SerializeField] protected float defaultVolume = 1f;
+    [SerializeField] protected bool loop = false;
+
+    public string Name { get => name; }
+    public float DefaultVolume { get => defaultVolume; }
+    public float Volume { get => audioSource.volume; set => audioSource.volume = value; }
+    public bool Loop { get => audioSource.loop; set => audioSource.loop = value; }
+
+    /// <summary>
+    /// Sets the sound's audio source to the given AudioSource.
+    /// Also sets the source's volume and loop setting to the sound's default volume and loop setting.
+    /// </summary>
+    /// <param name="audioSource">The AudioSource to set this sound's audio source to.</param>
+    public virtual void InitialiseSound(AudioSource audioSource)
+    {
+        this.audioSource = audioSource;
+        Volume = defaultVolume;
+        Loop = loop;
+    }
+
+    /// <summary>
+    /// Plays the sound.
+    /// </summary>
+    public abstract void Play();
+
+    /// <summary>
+    /// Pauses the sound.
+    /// </summary>
+    public virtual void Pause()
+    {
+        audioSource.Pause();
+    }
+
+    /// <summary>
+    /// Stops the sound.
+    /// </summary>
+    public virtual void Stop()
+    {
+        audioSource.Stop();
+    }
+}

--- a/Assets/Scripts/Audio/Sound.cs
+++ b/Assets/Scripts/Audio/Sound.cs
@@ -4,12 +4,10 @@ public abstract class Sound
 {
     protected AudioSource audioSource;
 
-    [SerializeField] protected string name;
     [Range(0, 1)]
     [SerializeField] protected float defaultVolume = 1f;
     [SerializeField] protected bool loop = false;
 
-    public string Name { get => name; }
     public float DefaultVolume { get => defaultVolume; }
     public float Volume { get => audioSource.volume; set => audioSource.volume = value; }
     public bool Loop { get => audioSource.loop; set => audioSource.loop = value; }

--- a/Assets/Scripts/Audio/Sound.cs.meta
+++ b/Assets/Scripts/Audio/Sound.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 20081183452c5024981470e37ba03d5e
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Audio/SoundFx.cs
+++ b/Assets/Scripts/Audio/SoundFx.cs
@@ -1,0 +1,39 @@
+using UnityEngine;
+
+[System.Serializable]
+public class SoundFx : Sound
+{
+    [Tooltip("A random audio clip will be chosen from this list each time the sound is played.")]
+    [SerializeField] private AudioClip[] audioClips;
+
+    /// <summary>
+    /// Sets the sound's audio source to the given AudioSource.
+    /// Also sets the source's volume and loop setting to the sound's default volume and loop setting.
+    /// </summary>
+    /// <remarks>The source's audio clip is set to the sound effect's first audio clip.</remarks>
+    /// <param name="audioSource">The AudioSource to set this sound's audio source to.</param>
+    public override void InitialiseSound(AudioSource audioSource)
+    {
+        if (audioClips.Length == 0)
+        {
+            Debug.LogError($"SoundFx [{name}] has no audio clips set.");
+            return;
+        }
+
+        audioSource.clip = audioClips[0];
+        base.InitialiseSound(audioSource);
+    }
+
+    /// <summary>
+    /// Plays the sound FX. If multiple audio clips are available, a random one is played.
+    /// </summary>
+    public override void Play()
+    {
+        if (audioClips.Length > 1)
+        {
+            audioSource.clip = audioClips[Random.Range(0, audioClips.Length)];
+        }
+
+        audioSource.Play();
+    }
+}

--- a/Assets/Scripts/Audio/SoundFx.cs
+++ b/Assets/Scripts/Audio/SoundFx.cs
@@ -3,8 +3,19 @@ using UnityEngine;
 [System.Serializable]
 public class SoundFx : Sound
 {
+    public enum LibraryIndex
+    {
+        MELEE_ATTACK_HIT,
+        MELEE_ATTACK_HIT_BLOCK
+    }
+
+    [Space(10)]
+
+    [SerializeField] private LibraryIndex libraryIndex;
     [Tooltip("A random audio clip will be chosen from this list each time the sound is played.")]
     [SerializeField] private AudioClip[] audioClips;
+
+    public LibraryIndex Index { get => libraryIndex; }
 
     /// <summary>
     /// Sets the sound's audio source to the given AudioSource.
@@ -16,7 +27,7 @@ public class SoundFx : Sound
     {
         if (audioClips.Length == 0)
         {
-            Debug.LogError($"SoundFx [{name}] has no audio clips set.");
+            Debug.LogError($"SoundFx [{System.Enum.GetName(typeof(LibraryIndex), libraryIndex)}] has no audio clips set.");
             return;
         }
 

--- a/Assets/Scripts/Audio/SoundFx.cs.meta
+++ b/Assets/Scripts/Audio/SoundFx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d090ef94a932a044c808c5094db146f1
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
There is now an Audio Manager prefab that is placed as a child object of the Game Manager object in the Test scene. The prefab itself is in the Assets/Prefabs/Audio folder. It has 3 components attached:
- `AudioManager`, a singleton that exposes methods for playing/stopping sound effects and music on the local client
- `AudioManagerSynced`, a singleton that exposes methods that mirror those in `AudioManager` except that the sound will be played/stopped on all clients
- `PhotonView` for RPC calls from `AudioManagerSynced`

To play a sound during runtime, the sound effect/music data must first be added to the sound effect/music list on the prefab's `AudioManager` component. This should automatically update the prefab instance in the scene without actually having to modify the scene itself. Once the data is added, the sound can be played from any script that is running in the same scene using, for example:
- `AudioManager.Instance.PlaySoundFx(...)` to play on the local client only, or
- `AudioManagerSynced.Instance.PlaySoundFx(...)` to play the sound on all clients

The full list of exposed methods for manipulating sounds are:
- `SetAudioVolume` to set the volume level of the entire game
- `PlaySoundFx` to play a sound effect
- `StopSoundFx` to stop playing a sound effectt
- `PlayMusic` to start playing or resume playing a music track
- `PauseMusic` to pause a music track
- `StopMusic` to stop a music track completely

For this pull request, the Test scene was modified:
- Audio Manager prefab object was added as a child object of Game Manager object