### PR TITLE
Add exit to role select feature when in game

### DIFF
--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -105,6 +105,9 @@ MonoBehaviour:
   - RPC_StopMusic
   - RPC_StopSoundFx
   - RPC_SyncPuzzleCompleted
+  - RPC_SyncMessage
+  - RPC_CancelExitRequest
+  - RPC_RequestExit
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Prefabs/UI/EscapeMenu.prefab
+++ b/Assets/Prefabs/UI/EscapeMenu.prefab
@@ -135,36 +135,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   button: {fileID: 3586180928542217240}
+  buttonText: {fileID: 1985707741944191157}
+  toggledText: Cancel Exit
   toggleOnEvent:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: AttemptRestart
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   toggleOffEvent:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: CancelRestartRequest
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!1 &4381396471496239369
 GameObject:
   m_ObjectHideFlags: 0
@@ -285,19 +263,7 @@ MonoBehaviour:
   m_TargetGraphic: {fileID: 4381396471496239370}
   m_OnClick:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: LeaveRoom
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!1 &4381396471862673648
 GameObject:
   m_ObjectHideFlags: 0
@@ -779,36 +745,14 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   button: {fileID: 4381396473350132996}
+  buttonText: {fileID: 4381396472077950450}
+  toggledText: Cancel Restart
   toggleOnEvent:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: AttemptRestart
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
   toggleOffEvent:
     m_PersistentCalls:
-      m_Calls:
-      - m_Target: {fileID: 0}
-        m_TargetAssemblyTypeName: RoomManager, Assembly-CSharp
-        m_MethodName: CancelRestartRequest
-        m_Mode: 1
-        m_Arguments:
-          m_ObjectArgument: {fileID: 0}
-          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
-          m_IntArgument: 0
-          m_FloatArgument: 0
-          m_StringArgument: 
-          m_BoolArgument: 0
-        m_CallState: 2
+      m_Calls: []
 --- !u!1 &5619736351052998428
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -919,6 +919,8 @@ GameObject:
   - component: {fileID: 208754546}
   - component: {fileID: 208754548}
   - component: {fileID: 208754547}
+  - component: {fileID: 208754549}
+  - component: {fileID: 208754550}
   m_Layer: 5
   m_Name: Restart_Message
   m_TagString: Untagged
@@ -1042,6 +1044,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 208754545}
   m_CullTransparentMesh: 1
+--- !u!114 &208754549
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 208754545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: daa5117b97c08854582d20276eff5435, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textObject: {fileID: 208754547}
+  timerDuration: 3
+  photonView: {fileID: 208754550}
+--- !u!114 &208754550
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 208754545}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 26
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1001 &246114858
 PrefabInstance:
   m_ObjectHideFlags: 0
@@ -1876,6 +1915,36 @@ MonoBehaviour:
       - m_Target: {fileID: 1710262033}
         m_TargetAssemblyTypeName: GameMessageUI, Assembly-CSharp
         m_MethodName: UpdateRestartMessage
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
+  requestExitEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1710262033}
+        m_TargetAssemblyTypeName: GameMessageUI, Assembly-CSharp
+        m_MethodName: UpdateExitMessage
+        m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+  cancelExitEvent:
+    m_PersistentCalls:
+      m_Calls:
+      - m_Target: {fileID: 1710262033}
+        m_TargetAssemblyTypeName: GameMessageUI, Assembly-CSharp
+        m_MethodName: UpdateExitMessage
         m_Mode: 6
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
@@ -2733,6 +2802,8 @@ GameObject:
   - component: {fileID: 1350348366}
   - component: {fileID: 1350348368}
   - component: {fileID: 1350348367}
+  - component: {fileID: 1350348369}
+  - component: {fileID: 1350348370}
   m_Layer: 5
   m_Name: Exit_Message
   m_TagString: Untagged
@@ -2856,6 +2927,43 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1350348365}
   m_CullTransparentMesh: 1
+--- !u!114 &1350348369
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350348365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: daa5117b97c08854582d20276eff5435, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  textObject: {fileID: 1350348367}
+  timerDuration: 3
+  photonView: {fileID: 1350348370}
+--- !u!114 &1350348370
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350348365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 27
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &1355652608
 GameObject:
   m_ObjectHideFlags: 0
@@ -2936,6 +3044,62 @@ PrefabInstance:
   m_Modification:
     m_TransformParent: {fileID: 65787071}
     m_Modifications:
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 765560306}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
+      value: 
+      objectReference: {fileID: 765560306}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: AttemptExit
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
+      value: CancelExitRequest
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: RoomManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: RoomManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
     - target: {fileID: 4381396471472462812, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_Pivot.x
       value: 0.5
@@ -3087,7 +3251,7 @@ PrefabInstance:
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 1710262033}
+      objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -3095,7 +3259,7 @@ PrefabInstance:
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 1710262033}
+      objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
@@ -3614,8 +3778,8 @@ GameObject:
   - component: {fileID: 1710262029}
   - component: {fileID: 1710262030}
   - component: {fileID: 1710262031}
-  - component: {fileID: 1710262033}
   - component: {fileID: 1710262034}
+  - component: {fileID: 1710262033}
   - component: {fileID: 1710262032}
   m_Layer: 5
   m_Name: InGame_UI
@@ -3709,8 +3873,8 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c580c104f44d9a04c9c65e411d4e7a1e, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
-  photonView: {fileID: 1710262032}
-  textObject: {fileID: 208754547}
+  restartMessage: {fileID: 208754549}
+  exitMessage: {fileID: 1350348369}
 --- !u!114 &1710262034
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -276,7 +276,6 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 0, y: 0, z: 0}
   m_Children:
-  - {fileID: 208754546}
   - {fileID: 1710262029}
   - {fileID: 1388879152}
   m_Father: {fileID: 0}
@@ -921,7 +920,7 @@ GameObject:
   - component: {fileID: 208754548}
   - component: {fileID: 208754547}
   m_Layer: 5
-  m_Name: Ingame_Message
+  m_Name: Restart_Message
   m_TagString: Untagged
   m_Icon: {fileID: 0}
   m_NavMeshLayer: 0
@@ -938,13 +937,13 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 65787071}
+  m_Father: {fileID: 1775396071}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 1}
-  m_AnchorMax: {x: 1, y: 1}
-  m_AnchoredPosition: {x: 60, y: -275}
-  m_SizeDelta: {x: -120, y: 437}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 300, y: 0}
+  m_SizeDelta: {x: 500, y: 50}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!114 &208754547
 MonoBehaviour:
@@ -2723,6 +2722,140 @@ CanvasRenderer:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1330603102}
   m_CullTransparentMesh: 1
+--- !u!1 &1350348365
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1350348366}
+  - component: {fileID: 1350348368}
+  - component: {fileID: 1350348367}
+  m_Layer: 5
+  m_Name: Exit_Message
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1350348366
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350348365}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 1775396071}
+  m_RootOrder: 1
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 0.5}
+  m_AnchorMax: {x: 0, y: 0.5}
+  m_AnchoredPosition: {x: 300, y: -40}
+  m_SizeDelta: {x: 500, y: 50}
+  m_Pivot: {x: 0.5, y: 0.5}
+--- !u!114 &1350348367
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350348365}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f4688fdb7df04437aeb418b961361dc5, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  m_Material: {fileID: 0}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_RaycastTarget: 1
+  m_RaycastPadding: {x: 0, y: 0, z: 0, w: 0}
+  m_Maskable: 1
+  m_OnCullStateChanged:
+    m_PersistentCalls:
+      m_Calls: []
+  m_text: 
+  m_isRightToLeft: 0
+  m_fontAsset: {fileID: 11400000, guid: a86ae438b5796084fbb835c1c14b12e7, type: 2}
+  m_sharedMaterial: {fileID: 4567519300188514924, guid: a86ae438b5796084fbb835c1c14b12e7, type: 2}
+  m_fontSharedMaterials: []
+  m_fontMaterial: {fileID: 0}
+  m_fontMaterials: []
+  m_fontColor32:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontColor: {r: 1, g: 1, b: 1, a: 1}
+  m_enableVertexGradient: 0
+  m_colorMode: 3
+  m_fontColorGradient:
+    topLeft: {r: 1, g: 1, b: 1, a: 1}
+    topRight: {r: 1, g: 1, b: 1, a: 1}
+    bottomLeft: {r: 1, g: 1, b: 1, a: 1}
+    bottomRight: {r: 1, g: 1, b: 1, a: 1}
+  m_fontColorGradientPreset: {fileID: 0}
+  m_spriteAsset: {fileID: 0}
+  m_tintAllSprites: 0
+  m_StyleSheet: {fileID: 0}
+  m_TextStyleHashCode: -1183493901
+  m_overrideHtmlColors: 0
+  m_faceColor:
+    serializedVersion: 2
+    rgba: 4294967295
+  m_fontSize: 20
+  m_fontSizeBase: 20
+  m_fontWeight: 400
+  m_enableAutoSizing: 0
+  m_fontSizeMin: 18
+  m_fontSizeMax: 72
+  m_fontStyle: 0
+  m_HorizontalAlignment: 1
+  m_VerticalAlignment: 256
+  m_textAlignment: 65535
+  m_characterSpacing: 0
+  m_wordSpacing: 0
+  m_lineSpacing: 0
+  m_lineSpacingMax: 0
+  m_paragraphSpacing: 0
+  m_charWidthMaxAdj: 0
+  m_enableWordWrapping: 1
+  m_wordWrappingRatios: 0.4
+  m_overflowMode: 0
+  m_linkedTextComponent: {fileID: 0}
+  parentLinkedComponent: {fileID: 0}
+  m_enableKerning: 1
+  m_enableExtraPadding: 0
+  checkPaddingRequired: 0
+  m_isRichText: 1
+  m_parseCtrlCharacters: 1
+  m_isOrthographic: 1
+  m_isCullingEnabled: 0
+  m_horizontalMapping: 0
+  m_verticalMapping: 0
+  m_uvLineOffset: 0
+  m_geometrySortingOrder: 0
+  m_IsTextObjectScaleStatic: 0
+  m_VertexBufferAutoSizeReduction: 0
+  m_useMaxVisibleDescender: 1
+  m_pageToDisplay: 1
+  m_margin: {x: 0, y: 0, z: 0, w: 0}
+  m_isUsingLegacyAnimationComponent: 0
+  m_isVolumetricText: 0
+  m_hasFontAssetChanged: 0
+  m_baseMaterial: {fileID: 0}
+  m_maskOffset: {x: 0, y: 0, z: 0, w: 0}
+--- !u!222 &1350348368
+CanvasRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1350348365}
+  m_CullTransparentMesh: 1
 --- !u!1 &1355652608
 GameObject:
   m_ObjectHideFlags: 0
@@ -2753,11 +2886,11 @@ RectTransform:
   - {fileID: 794630387}
   - {fileID: 1783460113}
   m_Father: {fileID: 1710262029}
-  m_RootOrder: 0
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 0, y: 0.5}
-  m_AnchorMax: {x: 0, y: 0.5}
-  m_AnchoredPosition: {x: 100, y: 0}
+  m_AnchorMin: {x: 0, y: 0}
+  m_AnchorMax: {x: 0, y: 0}
+  m_AnchoredPosition: {x: 100, y: 74}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &1363726816
@@ -2813,7 +2946,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4381396471472462812, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_RootOrder
-      value: 2
+      value: 3
       objectReference: {fileID: 0}
     - target: {fileID: 4381396471472462812, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_AnchorMax.x
@@ -3502,15 +3635,16 @@ RectTransform:
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
+  - {fileID: 1775396071}
   - {fileID: 1355652609}
   - {fileID: 2025394759}
   m_Father: {fileID: 65787071}
-  m_RootOrder: 1
+  m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
   m_AnchorMin: {x: 0, y: 0}
-  m_AnchorMax: {x: 1, y: 0}
-  m_AnchoredPosition: {x: 0, y: 20}
-  m_SizeDelta: {x: 0, y: 100}
+  m_AnchorMax: {x: 1, y: 1}
+  m_AnchoredPosition: {x: 0, y: 0}
+  m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0}
 --- !u!222 &1710262030
 CanvasRenderer:
@@ -3628,6 +3762,43 @@ RectTransform:
   m_AnchoredPosition: {x: 0, y: 0}
   m_SizeDelta: {x: 0, y: 0}
   m_Pivot: {x: 0.5, y: 0.5}
+--- !u!1 &1775396070
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 1775396071}
+  m_Layer: 5
+  m_Name: InGame_Message_UI
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!224 &1775396071
+RectTransform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 1775396070}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 208754546}
+  - {fileID: 1350348366}
+  m_Father: {fileID: 1710262029}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+  m_AnchorMin: {x: 0, y: 1}
+  m_AnchorMax: {x: 0, y: 1}
+  m_AnchoredPosition: {x: 70, y: 0}
+  m_SizeDelta: {x: 600, y: 150}
+  m_Pivot: {x: -0.000000006519258, y: 1}
 --- !u!1 &1783460112
 GameObject:
   m_ObjectHideFlags: 0
@@ -3818,11 +3989,11 @@ RectTransform:
   - {fileID: 1487838255}
   - {fileID: 2068160357}
   m_Father: {fileID: 1710262029}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
-  m_AnchorMin: {x: 1, y: 0.5}
-  m_AnchorMax: {x: 1, y: 0.5}
-  m_AnchoredPosition: {x: -100, y: 0}
+  m_AnchorMin: {x: 1, y: 0}
+  m_AnchorMax: {x: 1, y: 0}
+  m_AnchoredPosition: {x: -100, y: 74}
   m_SizeDelta: {x: 100, y: 100}
   m_Pivot: {x: 0.5, y: 0.5}
 --- !u!1 &2068160356

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -2888,12 +2888,32 @@ PrefabInstance:
       value: 0
       objectReference: {fileID: 0}
     - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.size
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 765560306}
     - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: LeaveRoom
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
+      value: RoomManager, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396471496239371, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: m_OnClick.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 4381396471862673648, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: m_Name
@@ -2944,7 +2964,15 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 1710262033}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}

--- a/Assets/Scenes/Level 1.unity
+++ b/Assets/Scenes/Level 1.unity
@@ -3046,7 +3046,7 @@ PrefabInstance:
     m_Modifications:
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.size
@@ -3054,6 +3054,10 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
+      value: 1
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
@@ -3065,11 +3069,19 @@ PrefabInstance:
       value: 
       objectReference: {fileID: 765560306}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Target
+      value: 
+      objectReference: {fileID: 1408170908}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
       objectReference: {fileID: 765560306}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_CallState
+      value: 2
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_CallState
       value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
@@ -3081,6 +3093,10 @@ PrefabInstance:
       value: AttemptExit
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
+      value: ToggleOffIfToggledOn
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
       value: CancelExitRequest
       objectReference: {fileID: 0}
@@ -3089,11 +3105,19 @@ PrefabInstance:
       value: RoomManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
+      value: ToggleableButton, Assembly-CSharp
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
       value: RoomManager, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
@@ -3222,7 +3246,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.size
-      value: 1
+      value: 2
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.size
@@ -3234,7 +3258,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Mode
-      value: 6
+      value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Mode
@@ -3251,7 +3275,7 @@ PrefabInstance:
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Target
       value: 
-      objectReference: {fileID: 0}
+      objectReference: {fileID: 1795722081}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Target
       value: 
@@ -3282,7 +3306,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_MethodName
-      value: UpdateRestartMessage
+      value: ToggleOffIfToggledOn
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_MethodName
@@ -3298,7 +3322,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_TargetAssemblyTypeName
-      value: GameMessageUI, Assembly-CSharp
+      value: ToggleableButton, Assembly-CSharp
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_TargetAssemblyTypeName
@@ -3317,7 +3341,15 @@ PrefabInstance:
       value: 1
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_BoolArgument
+      value: 0
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
       propertyPath: toggleOnEvent.m_PersistentCalls.m_Calls.Array.data[1].m_Arguments.m_ObjectArgumentAssemblyTypeName
+      value: UnityEngine.Object, UnityEngine
+      objectReference: {fileID: 0}
+    - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+      propertyPath: toggleOffEvent.m_PersistentCalls.m_Calls.Array.data[0].m_Arguments.m_ObjectArgumentAssemblyTypeName
       value: UnityEngine.Object, UnityEngine
       objectReference: {fileID: 0}
     - target: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
@@ -3336,6 +3368,17 @@ GameObject:
   m_CorrespondingSourceObject: {fileID: 4381396471862673648, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
   m_PrefabInstance: {fileID: 1388879151}
   m_PrefabAsset: {fileID: 0}
+--- !u!114 &1408170908 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 4381396473350132993, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+  m_PrefabInstance: {fileID: 1388879151}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56b6cd8d15995f446a0e78931241d508, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1487838254
 GameObject:
   m_ObjectHideFlags: 0
@@ -4066,6 +4109,17 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   slider: {fileID: 1783460114}
+--- !u!114 &1795722081 stripped
+MonoBehaviour:
+  m_CorrespondingSourceObject: {fileID: 1958532653574078223, guid: 84db37f7c2637a24cbe1eae2cda843ee, type: 3}
+  m_PrefabInstance: {fileID: 1388879151}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 0}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 56b6cd8d15995f446a0e78931241d508, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &1992689278
 GameObject:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Network/RoomManager.cs
+++ b/Assets/Scripts/Network/RoomManager.cs
@@ -115,12 +115,14 @@ public class RoomManager : MonoBehaviourPunCallbacks
     {
         Debug.Log("Partner is requesting restart");
         isRequestingRestart = true;
+        isRequestingExit = false;
     }
 
     [PunRPC]
     private void RPC_RequestExit()
     {
         Debug.Log("Partner is requesting to exit");
+        isRequestingRestart = false;
         isRequestingExit = true;
     }
 

--- a/Assets/Scripts/Network/RoomManager.cs
+++ b/Assets/Scripts/Network/RoomManager.cs
@@ -23,6 +23,8 @@ public class RoomManager : MonoBehaviourPunCallbacks
 
     [SerializeField] private UnityEvent requestRestartEvent;
     [SerializeField] private UnityEvent cancelRestartEvent;
+    [SerializeField] private UnityEvent requestExitEvent;
+    [SerializeField] private UnityEvent cancelExitEvent;
 
     public static void UpdateRoomProperty(string key, object value)
     {
@@ -63,10 +65,29 @@ public class RoomManager : MonoBehaviourPunCallbacks
         }
     }
 
+    public void AttemptExit()
+    {
+        if (isRequestingExit)
+        {
+            ExitToRoom();
+        }
+        else
+        {
+            RequestExit();
+            requestExitEvent.Invoke();
+        }
+    }
+
     public void CancelRestartRequest()
     {
         photonView.RPC("RPC_CancelRestartRequest", RpcTarget.Others);
         cancelRestartEvent.Invoke();
+    }
+
+    public void CancelExitRequest()
+    {
+        photonView.RPC("RPC_CancelExitRequest", RpcTarget.Others);
+        cancelExitEvent.Invoke();
     }
 
     private void RequestRestart()
@@ -74,9 +95,19 @@ public class RoomManager : MonoBehaviourPunCallbacks
         photonView.RPC("RPC_RequestRestart", RpcTarget.Others);
     }
 
+    private void RequestExit()
+    {
+        photonView.RPC("RPC_RequestExit", RpcTarget.Others);
+    }
+
     private void RestartLevel()
     {
         photonView.RPC("RPC_LoadGameLevel", RpcTarget.All);
+    }
+
+    private void ExitToRoom()
+    {
+        photonView.RPC("RPC_LoadRoomLevel", RpcTarget.All);
     }
 
     [PunRPC]
@@ -87,10 +118,24 @@ public class RoomManager : MonoBehaviourPunCallbacks
     }
 
     [PunRPC]
+    private void RPC_RequestExit()
+    {
+        Debug.Log("Partner is requesting to exit");
+        isRequestingExit = true;
+    }
+
+    [PunRPC]
     private void RPC_CancelRestartRequest()
     {
         Debug.Log("Partner is no longer requesting restart");
         isRequestingRestart = false;
+    }
+
+    [PunRPC]
+    private void RPC_CancelExitRequest()
+    {
+        Debug.Log("Partner is no longer requesting to exit");
+        isRequestingExit = false;
     }
 
     [PunRPC]

--- a/Assets/Scripts/Network/RoomManager.cs
+++ b/Assets/Scripts/Network/RoomManager.cs
@@ -11,10 +11,15 @@ using Hashtable = ExitGames.Client.Photon.Hashtable;
 public class RoomManager : MonoBehaviourPunCallbacks
 {
     private bool isRequestingRestart = false;
+    private bool isRequestingExit = false;
+
+    [Header("Scene Names")]
 
     [SerializeField] private string gameSceneName;
     [SerializeField] private string mainMenuSceneName;
     [SerializeField] private string roomSceneName;
+
+    [Header("Events")]
 
     [SerializeField] private UnityEvent requestRestartEvent;
     [SerializeField] private UnityEvent cancelRestartEvent;

--- a/Assets/Scripts/UI/GameMessage.cs
+++ b/Assets/Scripts/UI/GameMessage.cs
@@ -10,6 +10,7 @@ public class GameMessage : MonoBehaviour
     [SerializeField] private float timerDuration = 3.0f;
     [SerializeField] private PhotonView photonView;
 
+    private bool hasPartnerMessage = false;
     private Coroutine timeoutMessage;
 
     public void UpdateMessage(string message, bool hasTimeout)
@@ -23,6 +24,14 @@ public class GameMessage : MonoBehaviour
         }
 
         photonView.RPC("RPC_SyncMessage", RpcTarget.Others, message);
+    }
+
+    public void ClearOwnMessageIfExist()
+    {
+        if (!hasPartnerMessage && textObject.text != "")
+        {
+            ClearMessage();
+        }
     }
 
     private void ClearMessage()
@@ -54,5 +63,7 @@ public class GameMessage : MonoBehaviour
     {
         textObject.text = message;
         StopTimeoutIfRunning();
+
+        hasPartnerMessage = (message != "");
     }
 }

--- a/Assets/Scripts/UI/GameMessage.cs
+++ b/Assets/Scripts/UI/GameMessage.cs
@@ -1,0 +1,58 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+using TMPro;
+
+public class GameMessage : MonoBehaviour
+{
+    [SerializeField] private TextMeshProUGUI textObject;
+    [SerializeField] private float timerDuration = 3.0f;
+    [SerializeField] private PhotonView photonView;
+
+    private Coroutine timeoutMessage;
+
+    public void UpdateMessage(string message, bool hasTimeout)
+    {
+        textObject.text = message;
+        StopTimeoutIfRunning();
+
+        if (hasTimeout)
+        {
+            timeoutMessage = StartCoroutine(ClearMessageAfterTimeout());
+        }
+
+        photonView.RPC("RPC_SyncMessage", RpcTarget.Others, message);
+    }
+
+    private void ClearMessage()
+    {
+        textObject.text = "";
+
+        photonView.RPC("RPC_SyncMessage", RpcTarget.Others, "");
+    }
+
+    private void StopTimeoutIfRunning()
+    {
+        if (timeoutMessage != null)
+        {
+            StopCoroutine(timeoutMessage);
+            timeoutMessage = null; 
+        }
+    }
+
+    private IEnumerator ClearMessageAfterTimeout()
+    {
+        yield return new WaitForSeconds(timerDuration);
+        
+        StopTimeoutIfRunning();
+        ClearMessage();
+    }
+
+    [PunRPC]
+    public void RPC_SyncMessage(string message)
+    {
+        textObject.text = message;
+        StopTimeoutIfRunning();
+    }
+}

--- a/Assets/Scripts/UI/GameMessage.cs.meta
+++ b/Assets/Scripts/UI/GameMessage.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: daa5117b97c08854582d20276eff5435
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/UI/GameMessageUI.cs
+++ b/Assets/Scripts/UI/GameMessageUI.cs
@@ -1,23 +1,23 @@
 using System.Collections;
 using System.Collections.Generic;
 using UnityEngine;
-using Photon.Pun;
 using TMPro;
 
 using PlayerType = RoleSelectManager.PlayerType;
 
+public enum MessageType { RESTART, EXIT }
+
 public class GameMessageUI : MonoBehaviour
 {
-    public static readonly string MESSAGE_REQUESTING_RESTART = " is requesting to restart.";
-    public static readonly string MESSAGE_CANCELLED_RESTART = " is no longer requesting to restart.";
-
-    private readonly float timerDuration = 3.0f;
+    public static readonly string MESSAGE_REQUESTING = " is requesting to";
+    public static readonly string MESSAGE_CANCELLED= " is no longer requesting to";
+    public static readonly string MESSAGE_RESTART = " restart.";
+    public static readonly string MESSAGE_EXIT = " exit to role select.";
 
     private string playerString;
-    private Coroutine timeoutMessage;
 
-    [SerializeField] PhotonView photonView;
-    [SerializeField] private TextMeshProUGUI textObject;
+    [SerializeField] private GameMessage restartMessage;
+    [SerializeField] private GameMessage exitMessage;
 
     private void Start()
     {
@@ -36,53 +36,35 @@ public class GameMessageUI : MonoBehaviour
         }
     }
 
-    public void UpdateRestartMessage(bool isRestarting)
+    public void UpdateRestartMessage(bool isRequesting)
     {
-        string suffix;
+        string message = playerString;
 
-        if (isRestarting)
+        if (isRequesting)
         {
-            suffix = MESSAGE_REQUESTING_RESTART;
+            message += MESSAGE_REQUESTING + MESSAGE_RESTART;
+            restartMessage.UpdateMessage(message, false);
         } 
         else
         {
-            suffix = MESSAGE_CANCELLED_RESTART;
-            timeoutMessage = StartCoroutine(ExpireMessage());
+            message += MESSAGE_CANCELLED + MESSAGE_RESTART;
+            restartMessage.UpdateMessage(message, true);
         }
-
-        photonView.RPC("RPC_UpdateMessage", RpcTarget.All, playerString + suffix);
     }
 
-    private void ClearRequestMessageIfExist()
+    public void UpdateExitMessage(bool isRequesting)
     {
-        if (timeoutMessage != null)
+        string message = playerString;
+
+        if (isRequesting)
         {
-            StopCoroutine(timeoutMessage);
-            timeoutMessage = null;
+            message += MESSAGE_REQUESTING + MESSAGE_EXIT;
+            exitMessage.UpdateMessage(message, false);
         }
-
-        if (textObject.text.Equals(playerString + MESSAGE_CANCELLED_RESTART))
+        else
         {
-            photonView.RPC("RPC_ResetMessage", RpcTarget.All);
+            message += MESSAGE_CANCELLED + MESSAGE_EXIT;
+            exitMessage.UpdateMessage(message, true);
         }
-    }
-
-    private IEnumerator ExpireMessage()
-    {
-        yield return new WaitForSeconds(timerDuration);
-
-        ClearRequestMessageIfExist();
-    }
-
-    [PunRPC]
-    private void RPC_UpdateMessage(string message)
-    {
-        textObject.text = message;
-    }
-
-    [PunRPC]
-    private void RPC_ResetMessage()
-    {
-        textObject.text = "";
     }
 }

--- a/Assets/Scripts/UI/GameMessageUI.cs
+++ b/Assets/Scripts/UI/GameMessageUI.cs
@@ -50,6 +50,7 @@ public class GameMessageUI : MonoBehaviour
             message += MESSAGE_CANCELLED + MESSAGE_RESTART;
             restartMessage.UpdateMessage(message, true);
         }
+        exitMessage.ClearOwnMessageIfExist();
     }
 
     public void UpdateExitMessage(bool isRequesting)
@@ -66,5 +67,6 @@ public class GameMessageUI : MonoBehaviour
             message += MESSAGE_CANCELLED + MESSAGE_EXIT;
             exitMessage.UpdateMessage(message, true);
         }
+        restartMessage.ClearOwnMessageIfExist();
     }
 }

--- a/Assets/Scripts/UI/ToggleableButton.cs
+++ b/Assets/Scripts/UI/ToggleableButton.cs
@@ -4,24 +4,40 @@ using UnityEngine;
 using UnityEngine.Events;
 using UnityEngine.EventSystems;
 using UnityEngine.UI;
+using TMPro;
 
 public class ToggleableButton : MonoBehaviour, IPointerClickHandler
 {
     private bool isToggled = false;
     private Color untoggledColor;
     private Color toggledColor;
+    private string untoggledText;
     
+    [Header("UI")]
+
     [SerializeField] private Button button;
+    [SerializeField] private TextMeshProUGUI buttonText;
+    [SerializeField] private string toggledText;
+
+    [Header("Events")]
+
     [SerializeField] private UnityEvent toggleOnEvent;
     [SerializeField] private UnityEvent toggleOffEvent;
 
     void Start()
     {
+        
         untoggledColor = button.colors.normalColor;
         toggledColor = button.colors.pressedColor;
+        untoggledText = buttonText.text;
+
+        if (toggledText == "")
+        {
+            toggledText = untoggledText;
+        }
     }
 
-    private void UpdateColor()
+    private void UpdateVisuals()
     {
         ColorBlock cb = button.colors;
 
@@ -29,18 +45,20 @@ public class ToggleableButton : MonoBehaviour, IPointerClickHandler
         {
             cb.normalColor = toggledColor;
             button.colors = cb;
+            buttonText.text = toggledText;
         }
         else
         {
             cb.normalColor = untoggledColor;
             button.colors = cb;
+            buttonText.text = untoggledText;
         }
     }
 
     public void OnPointerClick(PointerEventData eventData)
     {
         isToggled = !isToggled;
-        UpdateColor();
+        UpdateVisuals();
 
         if (isToggled)
         {

--- a/Assets/Scripts/UI/ToggleableButton.cs
+++ b/Assets/Scripts/UI/ToggleableButton.cs
@@ -69,4 +69,13 @@ public class ToggleableButton : MonoBehaviour, IPointerClickHandler
             toggleOffEvent.Invoke();
         }
     }
+
+    public void ToggleOffIfToggledOn()
+    {
+        if (isToggled)
+        {
+            isToggled = false;
+            UpdateVisuals();
+        }
+    }
 }


### PR DESCRIPTION
Let's:
* Add the ability for players to exit to the role select screen when in game through the escape menu. This is useful for players who may want to restart the level but with different roles, or for selecting a different level. The feature functions almost exactly the same as the restart level feature.
* Add a new message UI element to display the new messages when players request or cancel an exit request.
* Add a new toggle-able button in the escape menu to allow players to request or cancel exit requests. If the player was already requesting a restart, the restart button will be toggled off and the restart request cancelled automatically. The same is true in reverse. (The exit button is toggled off and the exit request would be cancelled if the player changes their request to a restart)

Note:
Due to changes to the escape menu prefab, the escape menu in Level 2 scene is likely broken and not functional. Level 2 scene was left unmodified to limit the number of modified scenes. This issue will be fixed in a future PR.

![image](https://user-images.githubusercontent.com/77261657/161073176-10d8c81d-7e1b-4bbc-af84-0653944108ca.png)
![image](https://user-images.githubusercontent.com/77261657/161073300-d1ba3916-b57b-4ced-a230-528d5192f54b.png)