### PR TITLE
Update ranged knight enemy graphics

### DIFF
--- a/Assets/Animations/Enemy Knight Ranged/Attack.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Attack.anim
@@ -20,20 +20,24 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300182, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.071428575
-      value: {fileID: 21300184, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.14285715
-      value: {fileID: 21300186, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.21428572
-      value: {fileID: 21300188, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.42857143
-      value: {fileID: 21300188, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - time: 0.25
+      value: {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
+    - time: 0.375
+      value: {fileID: 21300000, guid: b80d095e5dba2f54eb1102cc1ee065c3, type: 3}
+    - time: 0.5
+      value: {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - time: 0.625
+      value: {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - time: 0.75
+      value: {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 14
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -48,17 +52,19 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300182, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300184, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300186, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300188, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300188, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
+    - {fileID: 21300000, guid: b80d095e5dba2f54eb1102cc1ee065c3, type: 3}
+    - {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.5
+    m_StopTime: 0.875
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -78,14 +84,14 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.14285715
+  - time: 0.25
     functionName: ExecuteAttackEffect
     data: 
     objectReferenceParameter: {fileID: 0}
     floatParameter: 0
     intParameter: 0
     messageOptions: 0
-  - time: 0.35714287
+  - time: 0.625
     functionName: OnAttackEnd
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Animations/Enemy Knight Ranged/Bow.meta
+++ b/Assets/Animations/Enemy Knight Ranged/Bow.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 5733fb160845d5c4f96bc54470f09a17
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Enemy Knight Ranged/Bow/Attack.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/Attack.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300000, guid: aa1d76f5084823b419aa9d3faa901695, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: aa1d76f5084823b419aa9d3faa901695, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Enemy Knight Ranged/Bow/Attack.anim.meta
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/Attack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 0715fd898711d694092e270e270444fe
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Enemy Knight Ranged/Bow/Graphics.controller
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/Graphics.controller
@@ -1,0 +1,159 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!1102 &-9187657893708890578
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ReadyAttack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: -2465374159286123549}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: ec5c240fb91ecbf40b66981241ea8207, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 
+--- !u!1107 &-3535487448796866858
+AnimatorStateMachine:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Base Layer
+  m_ChildStates:
+  - serializedVersion: 1
+    m_State: {fileID: -9187657893708890578}
+    m_Position: {x: 250, y: 110, z: 0}
+  - serializedVersion: 1
+    m_State: {fileID: 8617946666520571225}
+    m_Position: {x: 500, y: 110, z: 0}
+  m_ChildStateMachines: []
+  m_AnyStateTransitions: []
+  m_EntryTransitions: []
+  m_StateMachineTransitions: {}
+  m_StateMachineBehaviours: []
+  m_AnyStatePosition: {x: 50, y: 20, z: 0}
+  m_EntryPosition: {x: 50, y: 120, z: 0}
+  m_ExitPosition: {x: 800, y: 120, z: 0}
+  m_ParentStateMachinePosition: {x: 800, y: 20, z: 0}
+  m_DefaultState: {fileID: -9187657893708890578}
+--- !u!1101 &-2465374159286123549
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 1
+    m_ConditionEvent: isAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: 8617946666520571225}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!91 &9100000
+AnimatorController:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Graphics
+  serializedVersion: 5
+  m_AnimatorParameters:
+  - m_Name: isAttacking
+    m_Type: 4
+    m_DefaultFloat: 0
+    m_DefaultInt: 0
+    m_DefaultBool: 0
+    m_Controller: {fileID: 0}
+  m_AnimatorLayers:
+  - serializedVersion: 5
+    m_Name: Base Layer
+    m_StateMachine: {fileID: -3535487448796866858}
+    m_Mask: {fileID: 0}
+    m_Motions: []
+    m_Behaviours: []
+    m_BlendingMode: 0
+    m_SyncedLayerIndex: -1
+    m_DefaultWeight: 0
+    m_IKPass: 0
+    m_SyncedLayerAffectsTiming: 0
+    m_Controller: {fileID: 9100000}
+--- !u!1101 &5450993727721821032
+AnimatorStateTransition:
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: 
+  m_Conditions:
+  - m_ConditionMode: 2
+    m_ConditionEvent: isAttacking
+    m_EventTreshold: 0
+  m_DstStateMachine: {fileID: 0}
+  m_DstState: {fileID: -9187657893708890578}
+  m_Solo: 0
+  m_Mute: 0
+  m_IsExit: 0
+  serializedVersion: 3
+  m_TransitionDuration: 0
+  m_TransitionOffset: 0
+  m_ExitTime: 0
+  m_HasExitTime: 0
+  m_HasFixedDuration: 0
+  m_InterruptionSource: 0
+  m_OrderedInterruption: 1
+  m_CanTransitionToSelf: 1
+--- !u!1102 &8617946666520571225
+AnimatorState:
+  serializedVersion: 6
+  m_ObjectHideFlags: 1
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: Attack
+  m_Speed: 1
+  m_CycleOffset: 0
+  m_Transitions:
+  - {fileID: 5450993727721821032}
+  m_StateMachineBehaviours: []
+  m_Position: {x: 50, y: 50, z: 0}
+  m_IKOnFeet: 0
+  m_WriteDefaultValues: 1
+  m_Mirror: 0
+  m_SpeedParameterActive: 0
+  m_MirrorParameterActive: 0
+  m_CycleOffsetParameterActive: 0
+  m_TimeParameterActive: 0
+  m_Motion: {fileID: 7400000, guid: 0715fd898711d694092e270e270444fe, type: 2}
+  m_Tag: 
+  m_SpeedParameter: 
+  m_MirrorParameter: 
+  m_CycleOffsetParameter: 
+  m_TimeParameter: 

--- a/Assets/Animations/Enemy Knight Ranged/Bow/Graphics.controller.meta
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/Graphics.controller.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 80feb755e9feb0543bcf1d09bb86dc10
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 9100000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Enemy Knight Ranged/Bow/ReadyAttack.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/ReadyAttack.anim
@@ -1,0 +1,68 @@
+%YAML 1.1
+%TAG !u! tag:unity3d.com,2011:
+--- !u!74 &7400000
+AnimationClip:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_Name: ReadyAttack
+  serializedVersion: 6
+  m_Legacy: 0
+  m_Compressed: 0
+  m_UseHighQualityCurve: 1
+  m_RotationCurves: []
+  m_CompressedRotationCurves: []
+  m_EulerCurves: []
+  m_PositionCurves: []
+  m_ScaleCurves: []
+  m_FloatCurves: []
+  m_PPtrCurves:
+  - curve:
+    - time: 0
+      value: {fileID: 21300000, guid: 413fd9ee4a55abc40b387a67f207c9cd, type: 3}
+    attribute: m_Sprite
+    path: 
+    classID: 212
+    script: {fileID: 0}
+  m_SampleRate: 60
+  m_WrapMode: 0
+  m_Bounds:
+    m_Center: {x: 0, y: 0, z: 0}
+    m_Extent: {x: 0, y: 0, z: 0}
+  m_ClipBindingConstant:
+    genericBindings:
+    - serializedVersion: 2
+      path: 0
+      attribute: 0
+      script: {fileID: 0}
+      typeID: 212
+      customType: 23
+      isPPtrCurve: 1
+    pptrCurveMapping:
+    - {fileID: 21300000, guid: 413fd9ee4a55abc40b387a67f207c9cd, type: 3}
+  m_AnimationClipSettings:
+    serializedVersion: 2
+    m_AdditiveReferencePoseClip: {fileID: 0}
+    m_AdditiveReferencePoseTime: 0
+    m_StartTime: 0
+    m_StopTime: 0.016666668
+    m_OrientationOffsetY: 0
+    m_Level: 0
+    m_CycleOffset: 0
+    m_HasAdditiveReferencePose: 0
+    m_LoopTime: 1
+    m_LoopBlend: 0
+    m_LoopBlendOrientation: 0
+    m_LoopBlendPositionY: 0
+    m_LoopBlendPositionXZ: 0
+    m_KeepOriginalOrientation: 0
+    m_KeepOriginalPositionY: 1
+    m_KeepOriginalPositionXZ: 0
+    m_HeightFromFeet: 0
+    m_Mirror: 0
+  m_EditorCurves: []
+  m_EulerEditorCurves: []
+  m_HasGenericRootTransform: 0
+  m_HasMotionFloatCurves: 0
+  m_Events: []

--- a/Assets/Animations/Enemy Knight Ranged/Bow/ReadyAttack.anim.meta
+++ b/Assets/Animations/Enemy Knight Ranged/Bow/ReadyAttack.anim.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ec5c240fb91ecbf40b66981241ea8207
+NativeFormatImporter:
+  externalObjects: {}
+  mainObjectFileID: 7400000
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Animations/Enemy Knight Ranged/Death.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Death.anim
@@ -20,28 +20,14 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300092, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.09090909
-      value: {fileID: 21300094, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.18181819
-      value: {fileID: 21300096, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.27272728
-      value: {fileID: 21300098, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.36363637
-      value: {fileID: 21300100, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.45454547
-      value: {fileID: 21300102, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.54545456
-      value: {fileID: 21300104, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.6363636
-      value: {fileID: 21300106, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - time: 0.72727275
-      value: {fileID: 21300108, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 52456701ddf74244b8d08543ea70c831, type: 3}
+    - time: 0.16666667
+      value: {fileID: 21300000, guid: bd39cb69c38a50843aaf7ffb131ca723, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 11
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -56,21 +42,14 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300092, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300094, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300096, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300098, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300100, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300102, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300104, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300106, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300108, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 52456701ddf74244b8d08543ea70c831, type: 3}
+    - {fileID: 21300000, guid: bd39cb69c38a50843aaf7ffb131ca723, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.8181819
+    m_StopTime: 0.25
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Enemy Knight Ranged/DeathFalling.anim
+++ b/Assets/Animations/Enemy Knight Ranged/DeathFalling.anim
@@ -20,12 +20,14 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300046, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 9f2675f632e49fb43a7a75c8c0b7e99e, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 9f850bde258e2a64990a2d4252bd1bc1, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -40,13 +42,14 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300046, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 9f2675f632e49fb43a7a75c8c0b7e99e, type: 3}
+    - {fileID: 21300000, guid: 9f850bde258e2a64990a2d4252bd1bc1, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.25
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Enemy Knight Ranged/Flying.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Flying.anim
@@ -20,12 +20,18 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300038, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - time: 0.083333336
+      value: {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - time: 0.16666667
+      value: {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
+    - time: 0.25
+      value: {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 12
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -40,13 +46,16 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300038, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
+    - {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.33333334
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Enemy Knight Ranged/Hurt.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Hurt.anim
@@ -20,14 +20,20 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300042, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 50bdf118d881bb44bbce660deebd2477, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - time: 0.75
+      value: {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - time: 0.875
+      value: {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
     - time: 1
-      value: {fileID: 21300042, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -42,14 +48,17 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300042, guid: 0409f2fddf07780408257c186ab69681, type: 3}
-    - {fileID: 21300042, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 50bdf118d881bb44bbce660deebd2477, type: 3}
+    - {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
+    - {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 1.0166667
+    m_StopTime: 1.125
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0
@@ -69,7 +78,7 @@ AnimationClip:
   m_HasGenericRootTransform: 0
   m_HasMotionFloatCurves: 0
   m_Events:
-  - time: 0.98333335
+  - time: 0.875
     functionName: OnHurtEnd
     data: 
     objectReferenceParameter: {fileID: 0}

--- a/Assets/Animations/Enemy Knight Ranged/Idle.anim
+++ b/Assets/Animations/Enemy Knight Ranged/Idle.anim
@@ -20,12 +20,18 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300038, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - time: 0.25
+      value: {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
+    - time: 0.375
+      value: {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -40,13 +46,16 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300038, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+    - {fileID: 21300000, guid: 508a2fbe2ea569f4a9a63a22676529a0, type: 3}
+    - {fileID: 21300000, guid: 74f0b943d9e0a424a94d897ed8ef7812, type: 3}
+    - {fileID: 21300000, guid: 7dd6377ee4b52184a81df416bb48c9a3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.5
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Animations/Enemy Knight Ranged/ReadyAttack.anim
+++ b/Assets/Animations/Enemy Knight Ranged/ReadyAttack.anim
@@ -20,12 +20,18 @@ AnimationClip:
   m_PPtrCurves:
   - curve:
     - time: 0
-      value: {fileID: 21300182, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+      value: {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - time: 0.125
+      value: {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - time: 0.25
+      value: {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
+    - time: 0.375
+      value: {fileID: 21300000, guid: b80d095e5dba2f54eb1102cc1ee065c3, type: 3}
     attribute: m_Sprite
     path: 
     classID: 212
     script: {fileID: 0}
-  m_SampleRate: 60
+  m_SampleRate: 8
   m_WrapMode: 0
   m_Bounds:
     m_Center: {x: 0, y: 0, z: 0}
@@ -40,13 +46,16 @@ AnimationClip:
       customType: 23
       isPPtrCurve: 1
     pptrCurveMapping:
-    - {fileID: 21300182, guid: 0409f2fddf07780408257c186ab69681, type: 3}
+    - {fileID: 21300000, guid: 521b0d961e8272945a90e3c7ebe0aa5e, type: 3}
+    - {fileID: 21300000, guid: 69fe36d418bb4a249bbe79c06afd161a, type: 3}
+    - {fileID: 21300000, guid: be66b0091433c854585e0faad65de5f6, type: 3}
+    - {fileID: 21300000, guid: b80d095e5dba2f54eb1102cc1ee065c3, type: 3}
   m_AnimationClipSettings:
     serializedVersion: 2
     m_AdditiveReferencePoseClip: {fileID: 0}
     m_AdditiveReferencePoseTime: 0
     m_StartTime: 0
-    m_StopTime: 0.016666668
+    m_StopTime: 0.5
     m_OrientationOffsetY: 0
     m_Level: 0
     m_CycleOffset: 0

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -110,6 +110,8 @@ MonoBehaviour:
   - RPC_SyncMessage
   - RPC_CancelExitRequest
   - RPC_RequestExit
+  - RPC_HideProjectileLauncher
+  - RPC_ShowProjectileLauncher
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
+++ b/Assets/Photon/PhotonUnityNetworking/Resources/PhotonServerSettings.asset
@@ -112,6 +112,8 @@ MonoBehaviour:
   - RPC_RequestExit
   - RPC_HideProjectileLauncher
   - RPC_ShowProjectileLauncher
+  - RPC_StartAimingProjectileLauncher
+  - RPC_StopAimingProjectileLauncher
   DisableAutoOpenWizard: 1
   ShowSettings: 0
   DevRegionSetOnce: 1

--- a/Assets/Resources/Dragon Enemy Ranged.prefab
+++ b/Assets/Resources/Dragon Enemy Ranged.prefab
@@ -990,6 +990,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 2451902509671687090, guid: d75a65ad664c7a147bf5869d211fbe95, type: 3}
   projectileOrigin: {fileID: 9076783464814098838}
   projectilePathDisplay: {fileID: 2930949771930136818}
+  projectileLauncher: {fileID: 0}
   fireRangedProjectileEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Resources/Dragon.prefab
+++ b/Assets/Resources/Dragon.prefab
@@ -1013,6 +1013,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 2387202332680191168, guid: dd25e136c5def8448a844bb80b6468a9, type: 3}
   projectileOrigin: {fileID: 8972197996417656447}
   projectilePathDisplay: {fileID: 0}
+  projectileLauncher: {fileID: 0}
   fireRangedProjectileEvent:
     m_PersistentCalls:
       m_Calls: []

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -453,6 +453,7 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   photonView: {fileID: 3309789961085816945}
+  animator: {fileID: 6152516222421855209}
   transformToRotate: {fileID: 2133234025445900044}
 --- !u!114 &3309789961085816945
 MonoBehaviour:
@@ -472,7 +473,8 @@ MonoBehaviour:
   Synchronization: 3
   OwnershipTransfer: 0
   observableSearch: 2
-  ObservedComponents: []
+  ObservedComponents:
+  - {fileID: 951403960301512142}
   sceneViewId: 0
   InstantiationId: 0
   isRuntimeInstantiated: 0
@@ -1157,6 +1159,8 @@ GameObject:
   m_Component:
   - component: {fileID: 8874013032948693357}
   - component: {fileID: 1119147474727389363}
+  - component: {fileID: 6152516222421855209}
+  - component: {fileID: 951403960301512142}
   m_Layer: 0
   m_Name: Graphics
   m_TagString: Untagged
@@ -1229,3 +1233,46 @@ SpriteRenderer:
   m_WasSpriteAssigned: 1
   m_MaskInteraction: 0
   m_SpriteSortPoint: 0
+--- !u!95 &6152516222421855209
+Animator:
+  serializedVersion: 3
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8072661512646428728}
+  m_Enabled: 1
+  m_Avatar: {fileID: 0}
+  m_Controller: {fileID: 9100000, guid: 80feb755e9feb0543bcf1d09bb86dc10, type: 2}
+  m_CullingMode: 0
+  m_UpdateMode: 0
+  m_ApplyRootMotion: 0
+  m_LinearVelocityBlending: 0
+  m_WarningMessage: 
+  m_HasTransformHierarchy: 1
+  m_AllowConstantClipSamplingOptimization: 1
+  m_KeepAnimatorControllerStateOnDisable: 0
+--- !u!114 &951403960301512142
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8072661512646428728}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 9b8c4a61274f60b4ea5fb4299cfdbf14, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ShowLayerWeightsInspector: 1
+  ShowParameterInspector: 1
+  m_SynchronizeParameters:
+  - Type: 4
+    SynchronizeType: 0
+    Name: New Bool
+  - Type: 4
+    SynchronizeType: 2
+    Name: isAttacking
+  m_SynchronizeLayers:
+  - SynchronizeType: 0
+    LayerIndex: 0

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -31,7 +31,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 4861795074019271562}
-  m_RootOrder: 1
+  m_RootOrder: 2
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!120 &8931084091332783711
 LineRenderer:
@@ -199,7 +199,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 377565971814961089}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.015, y: -1.184, z: 0}
+  m_LocalPosition: {x: 0.015, y: -0.915, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2936445182765803178}
@@ -271,7 +271,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 835868337854515298}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.005, y: 0.269, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2936445182765803178}
@@ -301,7 +301,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.45, y: 1.32}
+  m_Size: {x: 0.5, y: 1.32}
   m_EdgeRadius: 0
 --- !u!1 &1217784505746131563
 GameObject:
@@ -329,7 +329,7 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 1217784505746131563}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.015, y: -0.511, z: 0}
+  m_LocalPosition: {x: 0.015, y: -0.24199998, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
   m_Father: {fileID: 2936445182765803178}
@@ -359,7 +359,7 @@ BoxCollider2D:
     adaptiveTiling: 0
   m_AutoTiling: 0
   serializedVersion: 2
-  m_Size: {x: 0.53, y: 1.275}
+  m_Size: {x: 0.58, y: 1.275}
   m_EdgeRadius: 0
 --- !u!114 &276739738191126824
 MonoBehaviour:
@@ -400,12 +400,82 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 2473908914833446661}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0.18, y: -0.201, z: 0}
+  m_LocalPosition: {x: 0.585, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 4586293857793589514}
-  m_RootOrder: 0
+  m_Father: {fileID: 2133234025445900044}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!1 &4680765129591477489
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 2133234025445900044}
+  - component: {fileID: 2866946741930019417}
+  - component: {fileID: 3309789961085816945}
+  m_Layer: 0
+  m_Name: Projectile Launcher
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 0
+--- !u!4 &2133234025445900044
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4680765129591477489}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: -0.035, y: 0.094, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children:
+  - {fileID: 8874013032948693357}
+  - {fileID: 2649109914065820118}
+  m_Father: {fileID: 2936445182765803178}
+  m_RootOrder: 4
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &2866946741930019417
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4680765129591477489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 4b6b48347cddee94aa3b2a05fc7f3d67, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  photonView: {fileID: 3309789961085816945}
+  transformToRotate: {fileID: 2133234025445900044}
+--- !u!114 &3309789961085816945
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4680765129591477489}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: aa584fbee541324448dd18d8409c7a41, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  ObservedComponentsFoldoutOpen: 1
+  Group: 0
+  prefixField: -1
+  Synchronization: 3
+  OwnershipTransfer: 0
+  observableSearch: 2
+  ObservedComponents: []
+  sceneViewId: 0
+  InstantiationId: 0
+  isRuntimeInstantiated: 0
 --- !u!1 &4861795074019271563
 GameObject:
   m_ObjectHideFlags: 0
@@ -447,6 +517,7 @@ Transform:
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children:
   - {fileID: 2497426802187544382}
+  - {fileID: 1279650190019030110}
   - {fileID: 2025364689731637937}
   - {fileID: 2936445182765803178}
   m_Father: {fileID: 0}
@@ -546,7 +617,19 @@ MonoBehaviour:
   navFastDistanceThreshold: 10
   flipDirectionEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2866946741930019417}
+        m_TargetAssemblyTypeName: ProjectileLauncher, Assembly-CSharp
+        m_MethodName: FlipDirection
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   movementSpeed: 2
 --- !u!114 &1860061280274303189
 MonoBehaviour:
@@ -585,10 +668,34 @@ MonoBehaviour:
       m_Calls: []
   hurtEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2866946741930019417}
+        m_TargetAssemblyTypeName: ProjectileLauncher, Assembly-CSharp
+        m_MethodName: HideProjectileLauncher
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   deathEvent:
     m_PersistentCalls:
-      m_Calls: []
+      m_Calls:
+      - m_Target: {fileID: 2866946741930019417}
+        m_TargetAssemblyTypeName: ProjectileLauncher, Assembly-CSharp
+        m_MethodName: HideProjectileLauncher
+        m_Mode: 1
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 0
+        m_CallState: 2
   reviveStartEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -764,12 +871,12 @@ Transform:
   m_PrefabInstance: {fileID: 0}
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 4965308107246612275}
-  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
   m_LocalPosition: {x: 0, y: 0, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
   m_Children: []
-  m_Father: {fileID: 2936445182765803178}
-  m_RootOrder: 4
+  m_Father: {fileID: 4861795074019271562}
+  m_RootOrder: 1
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!114 &7078817135768378733
 MonoBehaviour:
@@ -842,6 +949,7 @@ MonoBehaviour:
   projectilePrefab: {fileID: 2451902509671687090, guid: d75a65ad664c7a147bf5869d211fbe95, type: 3}
   projectileOrigin: {fileID: 2649109914065820118}
   projectilePathDisplay: {fileID: 4827889999406553579}
+  projectileLauncher: {fileID: 2866946741930019417}
   fireRangedProjectileEvent:
     m_PersistentCalls:
       m_Calls: []
@@ -876,9 +984,9 @@ Transform:
   - {fileID: 100489199290508864}
   - {fileID: 4660399142326900015}
   - {fileID: 402555776587635658}
-  - {fileID: 1279650190019030110}
+  - {fileID: 2133234025445900044}
   m_Father: {fileID: 4861795074019271562}
-  m_RootOrder: 2
+  m_RootOrder: 3
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
 --- !u!1 &7285648258761168874
 GameObject:
@@ -908,10 +1016,9 @@ Transform:
   m_PrefabAsset: {fileID: 0}
   m_GameObject: {fileID: 7285648258761168874}
   m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
-  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalPosition: {x: 0.129, y: -0.174, z: 0}
   m_LocalScale: {x: 1, y: 1, z: 1}
-  m_Children:
-  - {fileID: 2649109914065820118}
+  m_Children: []
   m_Father: {fileID: 2936445182765803178}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -955,8 +1062,8 @@ SpriteRenderer:
   m_SortingLayerID: -1327025917
   m_SortingLayer: 5
   m_SortingOrder: 0
-  m_Sprite: {fileID: 21300038, guid: 300ea1a5869382b43bf6149aba92c4db, type: 3}
-  m_Color: {r: 0.67058825, g: 0.25490198, b: 0.25490198, a: 1}
+  m_Sprite: {fileID: 21300000, guid: 68cc218b2ce7f804bb5afaa63350f67f, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
   m_FlipX: 0
   m_FlipY: 0
   m_DrawMode: 0
@@ -1040,3 +1147,85 @@ MonoBehaviour:
   m_SynchronizeLayers:
   - SynchronizeType: 2
     LayerIndex: 0
+--- !u!1 &8072661512646428728
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 8874013032948693357}
+  - component: {fileID: 1119147474727389363}
+  m_Layer: 0
+  m_Name: Graphics
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &8874013032948693357
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8072661512646428728}
+  m_LocalRotation: {x: -0, y: -0, z: -0, w: 1}
+  m_LocalPosition: {x: 0.193, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 2133234025445900044}
+  m_RootOrder: 0
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!212 &1119147474727389363
+SpriteRenderer:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 8072661512646428728}
+  m_Enabled: 1
+  m_CastShadows: 0
+  m_ReceiveShadows: 0
+  m_DynamicOccludee: 1
+  m_MotionVectors: 1
+  m_LightProbeUsage: 1
+  m_ReflectionProbeUsage: 1
+  m_RayTracingMode: 0
+  m_RayTraceProcedural: 0
+  m_RenderingLayerMask: 1
+  m_RendererPriority: 0
+  m_Materials:
+  - {fileID: 10754, guid: 0000000000000000f000000000000000, type: 0}
+  m_StaticBatchInfo:
+    firstSubMesh: 0
+    subMeshCount: 0
+  m_StaticBatchRoot: {fileID: 0}
+  m_ProbeAnchor: {fileID: 0}
+  m_LightProbeVolumeOverride: {fileID: 0}
+  m_ScaleInLightmap: 1
+  m_ReceiveGI: 1
+  m_PreserveUVs: 0
+  m_IgnoreNormalsForChartDetection: 0
+  m_ImportantGI: 0
+  m_StitchLightmapSeams: 1
+  m_SelectedEditorRenderState: 0
+  m_MinimumChartSize: 4
+  m_AutoUVMaxDistance: 0.5
+  m_AutoUVMaxAngle: 89
+  m_LightmapParameters: {fileID: 0}
+  m_SortingLayerID: -1352116357
+  m_SortingLayer: 6
+  m_SortingOrder: 0
+  m_Sprite: {fileID: 21300000, guid: 413fd9ee4a55abc40b387a67f207c9cd, type: 3}
+  m_Color: {r: 1, g: 1, b: 1, a: 1}
+  m_FlipX: 0
+  m_FlipY: 0
+  m_DrawMode: 0
+  m_Size: {x: 1, y: 1}
+  m_AdaptiveModeThreshold: 0.5
+  m_SpriteTileMode: 0
+  m_WasSpriteAssigned: 1
+  m_MaskInteraction: 0
+  m_SpriteSortPoint: 0

--- a/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
+++ b/Assets/Scripts/Actor Components/Combat/Combat Abilities/RangedAttackAbility.cs
@@ -15,6 +15,7 @@ public class RangedAttackAbility : CombatAbility
     [SerializeField] private RangedProjectile projectilePrefab;
     [SerializeField] private Transform projectileOrigin;
     [SerializeField] private ProjectilePathDisplay projectilePathDisplay;
+    [SerializeField] private ProjectileLauncher projectileLauncher;
 
     [Space(10)]
 
@@ -40,14 +41,15 @@ public class RangedAttackAbility : CombatAbility
             {
                 Transform target = (Transform)parameters[0];
                 combat.ActionStateMachine.ChangeState(new ReadyRangedAttackState(
-                    combat, target, projectilePathDisplay, timeToLock, readyDuration, ReadyCallback));
+                    combat, target, projectilePathDisplay, projectileLauncher,
+                    timeToLock, readyDuration, ReadyCallback));
             }
             else
             {
                 Vector2 direction = (Vector2)parameters[0];
                 combat.ActionStateMachine.ChangeState(new RangedAttackState(
-                    combat, projectilePrefab, projectileOrigin, direction, 
-                    combat.AttackEffectLayer, fireRangedProjectileEvent, resourceCost));
+                    combat, projectilePrefab, projectileOrigin, projectileLauncher, direction,
+                    combat.AttackEffectLayer, resourceCost, fireRangedProjectileEvent));
             }
         }
     }
@@ -56,7 +58,7 @@ public class RangedAttackAbility : CombatAbility
     {
         Vector2 direction = ((ReadyRangedAttackState)combat.ActionStateMachine.CurrState).TargetPosition - (Vector2)transform.position;
         combat.ActionStateMachine.ChangeState(new RangedAttackState(
-            combat, projectilePrefab, projectileOrigin, direction, 
-            combat.AttackEffectLayer, fireRangedProjectileEvent, resourceCost));
+            combat, projectilePrefab, projectileOrigin, projectileLauncher, direction, 
+            combat.AttackEffectLayer, resourceCost, fireRangedProjectileEvent));
     }
 }

--- a/Assets/Scripts/Actor Components/ProjectileLauncher.cs
+++ b/Assets/Scripts/Actor Components/ProjectileLauncher.cs
@@ -6,10 +6,13 @@ using Photon.Pun;
 public class ProjectileLauncher : MonoBehaviour
 {
     [SerializeField] private PhotonView photonView;
+    [SerializeField] private Animator animator;
     [SerializeField] private Transform transformToRotate;
 
     private bool isAimingAtTarget;
     private Transform target;
+
+    public Animator Animator { get => animator; }
 
     private void Update()
     {

--- a/Assets/Scripts/Actor Components/ProjectileLauncher.cs
+++ b/Assets/Scripts/Actor Components/ProjectileLauncher.cs
@@ -1,0 +1,66 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+using Photon.Pun;
+
+public class ProjectileLauncher : MonoBehaviour
+{
+    [SerializeField] private PhotonView photonView;
+
+    private bool isAimingAtTarget;
+    private Transform target;
+
+    private void Update()
+    {
+        if (isAimingAtTarget)
+        {
+            UpdateAimDirection();
+        }
+    }
+
+    public void ShowProjectileLauncher()
+    {
+        photonView.RPC("RPC_ShowProjectileLauncher", RpcTarget.All);
+    }
+
+    public void StartAimingProjectileLauncher(Transform target)
+    {
+        isAimingAtTarget = true;
+        this.target = target;
+    }
+
+    public void StopAimingProjectileLauncher()
+    {
+        isAimingAtTarget = false;
+        UpdateAimDirection();
+    }
+
+    public void HideProjectileLauncher()
+    {
+        photonView.RPC("RPC_HideProjectileLauncher", RpcTarget.All);
+    }
+
+    private void UpdateAimDirection()
+    {
+        Vector2 direction = target.position - transform.position;
+
+        // clamp direction to right-facing direction, since left-facing is handled by actor being flipped
+        direction = new Vector2(Mathf.Clamp(direction.x, 0f, direction.x), direction.y);
+
+        transform.rotation = Quaternion.AngleAxis(
+            Mathf.Atan2(direction.y, direction.x) * Mathf.Rad2Deg,
+            Vector3.forward);
+    }
+
+    [PunRPC]
+    private void RPC_ShowProjectileLauncher()
+    {
+        gameObject.SetActive(true);
+    }
+
+    [PunRPC]
+    private void RPC_HideProjectileLauncher()
+    {
+        gameObject.SetActive(false);
+    }
+}

--- a/Assets/Scripts/Actor Components/ProjectileLauncher.cs.meta
+++ b/Assets/Scripts/Actor Components/ProjectileLauncher.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 4b6b48347cddee94aa3b2a05fc7f3d67
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
@@ -50,6 +50,11 @@ namespace CombatStates
                 projectileOrigin.position,
                 RangedProjectile.GetRotationForDirection(attackDirection)).GetComponent<RangedProjectile>();
 
+            if (projectileLauncher != null)
+            {
+                projectileLauncher.Animator.SetBool("isAttacking", true);
+            }
+
             projectile.Direction = attackDirection;
             projectile.ActorTargetsLayer = actorHitLayer;
             fireRangedProjectileEvent.Invoke(projectile);
@@ -62,6 +67,7 @@ namespace CombatStates
             if (projectileLauncher != null)
             {
                 projectileLauncher.HideProjectileLauncher();
+                projectileLauncher.Animator.SetBool("isAttacking", false);
             }
         }
     }

--- a/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
@@ -32,12 +32,13 @@ namespace CombatStates
 
         public override void Enter()
         {
-            AudioManagerSynced.Instance.PlaySoundFx(owner.SoundFXIndexLibrary.Attack);
             base.Enter();
             if (Vector2.Angle(Vector2.up, attackDirection) > 170f)
             {
                 owner.Animator.SetBool("isAttackingDown", true);
             }
+
+            AudioManagerSynced.Instance.PlaySoundFx(owner.SoundFXIndexLibrary.Attack);
         }
 
         public override void ExecuteAttackEffect()

--- a/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Attack States/RangedAttackState.cs
@@ -9,23 +9,25 @@ namespace CombatStates
     {
         private readonly RangedProjectile projectilePrefab;
         private readonly Transform projectileOrigin;
+        private readonly ProjectileLauncher projectileLauncher;
         private readonly Vector2 attackDirection;
         private readonly LayerMask actorHitLayer;
-        private RangedProjectileEvent fireRangedProjectileEvent;
         private readonly float attackCost;
+        private readonly RangedProjectileEvent fireRangedProjectileEvent;
 
         public RangedAttackState(
-            Combat owner, RangedProjectile projectilePrefab,
-            Transform projectileOrigin, Vector2 attackDirection, LayerMask actorHitLayer,
-            RangedProjectileEvent fireRangedProjectileEvent,
-            float attackCost) : base(owner)
+            Combat owner,
+            RangedProjectile projectilePrefab, Transform projectileOrigin, ProjectileLauncher projectileLauncher,
+            Vector2 attackDirection, LayerMask actorHitLayer, float attackCost,
+            RangedProjectileEvent fireRangedProjectileEvent) : base(owner)
         {
             this.projectilePrefab = projectilePrefab;
             this.projectileOrigin = projectileOrigin;
+            this.projectileLauncher = projectileLauncher;
             this.attackDirection = attackDirection.normalized;
             this.actorHitLayer = actorHitLayer;
-            this.fireRangedProjectileEvent = fireRangedProjectileEvent;
             this.attackCost = attackCost;
+            this.fireRangedProjectileEvent = fireRangedProjectileEvent;
         }
 
         public override void Enter()
@@ -56,6 +58,10 @@ namespace CombatStates
         {
             base.Exit();
             owner.Animator.SetBool("isAttackingDown", false);
+            if (projectileLauncher != null)
+            {
+                projectileLauncher.HideProjectileLauncher();
+            }
         }
     }
 }

--- a/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
@@ -35,7 +35,6 @@ namespace CombatStates
             projectilePathDisplay.StartDrawingProjectilePath(target);
             if (projectileLauncher != null)
             {
-                projectileLauncher.ShowProjectileLauncher();
                 projectileLauncher.StartAimingProjectileLauncher(target);
             }
 

--- a/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
@@ -9,18 +9,21 @@ namespace CombatStates
     {
         private readonly Transform target;
         private readonly ProjectilePathDisplay projectilePathDisplay;
+        private readonly ProjectileLauncher projectileLauncher;
         private readonly float lockTargetPositionTime;
 
         public bool HasLockedTargetPosition { get; private set; }
         public Vector2 TargetPosition { get; private set; }
 
         public ReadyRangedAttackState(
-            Combat owner, Transform target, ProjectilePathDisplay projectilePathDisplay,
+            Combat owner, Transform target,
+            ProjectilePathDisplay projectilePathDisplay, ProjectileLauncher projectileLauncher,
             float lockTargetPositionTime, float readyDuration,
             UnityAction<Combat> readyCallback) : base(owner, readyDuration, readyCallback)
         {
             this.target = target;
             this.projectilePathDisplay = projectilePathDisplay;
+            this.projectileLauncher = projectileLauncher;
             this.lockTargetPositionTime = lockTargetPositionTime;
 
             HasLockedTargetPosition = false;
@@ -30,6 +33,12 @@ namespace CombatStates
         {
             base.Enter();
             projectilePathDisplay.StartDrawingProjectilePath(target);
+            if (projectileLauncher != null)
+            {
+                projectileLauncher.ShowProjectileLauncher();
+                projectileLauncher.StartAimingProjectileLauncher(target);
+            }
+
             AudioManagerSynced.Instance.PlaySoundFx(owner.SoundFXIndexLibrary.ReadyAttack);
         }
 
@@ -55,6 +64,10 @@ namespace CombatStates
             HasLockedTargetPosition = true;
             TargetPosition = target.position;
             projectilePathDisplay.StopUpdatingProjectilePath();
+            if (projectileLauncher != null)
+            {
+                projectileLauncher.StopAimingProjectileLauncher();
+            }
         }
     }
 }

--- a/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
+++ b/Assets/Scripts/State Machine/States/Action States/Ready Attack States/ReadyRangedAttackState.cs
@@ -8,7 +8,7 @@ namespace CombatStates
     public class ReadyRangedAttackState : ReadyAttackState
     {
         private readonly Transform target;
-        private ProjectilePathDisplay projectilePathDisplay;
+        private readonly ProjectilePathDisplay projectilePathDisplay;
         private readonly float lockTargetPositionTime;
 
         public bool HasLockedTargetPosition { get; private set; }
@@ -28,9 +28,9 @@ namespace CombatStates
 
         public override void Enter()
         {
-            AudioManagerSynced.Instance.PlaySoundFx(owner.SoundFXIndexLibrary.ReadyAttack);
             base.Enter();
             projectilePathDisplay.StartDrawingProjectilePath(target);
+            AudioManagerSynced.Instance.PlaySoundFx(owner.SoundFXIndexLibrary.ReadyAttack);
         }
 
         public override void Execute()
@@ -46,6 +46,7 @@ namespace CombatStates
         {
             base.Exit();
             projectilePathDisplay.StopDrawingProjectilePath();
+            AudioManagerSynced.Instance.StopSoundFx(owner.SoundFXIndexLibrary.ReadyAttack);
         }
 
         private void LockTargetPosition()

--- a/Assets/Sprites/Enemy/Knight.meta
+++ b/Assets/Sprites/Enemy/Knight.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: ed6052adc9c262143b5fe8c58cc39020
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged.meta
@@ -1,0 +1,8 @@
+fileFormatVersion: 2
+guid: 7d5f536dd0357e04bb37116056036594
+folderAsset: yes
+DefaultImporter:
+  externalObjects: {}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/Attack.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/Attack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9da54aba9013ec5b150351be912a6b23fad78627d7b393cec6bd123fdc0b4ced
+size 354

--- a/Assets/Sprites/Enemy/Knight/Ranged/Attack.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/Attack.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: aa1d76f5084823b419aa9d3faa901695
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase1.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:48d40a46b15a1a826a7cc29ad0a9f2474b1d6655df24d87a84237baa71f3da52
+size 728

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase1.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase1.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 521b0d961e8272945a90e3c7ebe0aa5e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase2.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9e7ece52a238a7920d8008b4890fb327dd018e1faaa6871e1abd69b4b731e762
+size 703

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase2.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase2.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 69fe36d418bb4a249bbe79c06afd161a
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase3.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:dd48360938752e264f41e67c3b86dbe0b0c979928a61cdb54ec4593137b5f727
+size 719

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase3.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase3.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: be66b0091433c854585e0faad65de5f6
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase4.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:5c9f0c69ada5bfd5c4b73493f323f3dfc67bcaa6bf96745c21a0000c185863c7
+size 717

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase4.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_AttackBase4.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: b80d095e5dba2f54eb1102cc1ee065c3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death1.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:940815fd42bfc484ae966d9b8b42cd43240ae1c8fb7a9f91e3a089611c792a84
+size 505

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death1.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death1.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 52456701ddf74244b8d08543ea70c831
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death2.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:262c6ceea229194332991180fcdd8d8f5520d68641b9abb282667d06462f9cb4
+size 458

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death2.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Death2.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: bd39cb69c38a50843aaf7ffb131ca723
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall1.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:da89b8adc4dd320e124904a092936ec82c4a5ab7e833106c53557dfe66383585
+size 707

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall1.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall1.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 9f2675f632e49fb43a7a75c8c0b7e99e
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall2.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:63123f906baeb083ee9cff16b1f0ac957469f48bd2d23add56136ce54c8f6dda
+size 706

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall2.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Fall2.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 9f850bde258e2a64990a2d4252bd1bc1
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Hurt.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Hurt.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de6c0f0cb393495536d0cf9d5de187cb169efd7db6a13b1484c59c7f2887f591
+size 401

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Hurt.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Hurt.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 50bdf118d881bb44bbce660deebd2477
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle1.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle1.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:9334a0e611af67d119e4f31d8a2ef0efabeddbc0142432e1350fe038d3b7965b
+size 894

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle1.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle1.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 68cc218b2ce7f804bb5afaa63350f67f
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle2.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle2.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8142c3e66fefb3b0f67458bb155f48350521fddb63d2d0ee785f2bb6ad91a3ca
+size 865

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle2.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle2.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 508a2fbe2ea569f4a9a63a22676529a0
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle3.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle3.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:8f2d4948ee0be0bb77b93a4cd80041a24e1ca44e36f25aa80da254a7b70c6fa1
+size 882

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle3.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle3.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 74f0b943d9e0a424a94d897ed8ef7812
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle4.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle4.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:de70d84a8b56729d32171426e38c9139a9d84dca11e0d9edf81691ff4a9b0be7
+size 860

--- a/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle4.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/PrinceEnemyRanged_Idle4.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 7dd6377ee4b52184a81df416bb48c9a3
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Sprites/Enemy/Knight/Ranged/ReadyAttack.png
+++ b/Assets/Sprites/Enemy/Knight/Ranged/ReadyAttack.png
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:142856931f6d7ce601e940c4805a368989a1437518e913edcf385d2a2d0e7acc
+size 388

--- a/Assets/Sprites/Enemy/Knight/Ranged/ReadyAttack.png.meta
+++ b/Assets/Sprites/Enemy/Knight/Ranged/ReadyAttack.png.meta
@@ -1,0 +1,120 @@
+fileFormatVersion: 2
+guid: 413fd9ee4a55abc40b387a67f207c9cd
+TextureImporter:
+  internalIDToNameTable: []
+  externalObjects: {}
+  serializedVersion: 11
+  mipmaps:
+    mipMapMode: 0
+    enableMipMap: 0
+    sRGBTexture: 1
+    linearTexture: 0
+    fadeOut: 0
+    borderMipMap: 0
+    mipMapsPreserveCoverage: 0
+    alphaTestReferenceValue: 0.5
+    mipMapFadeDistanceStart: 1
+    mipMapFadeDistanceEnd: 3
+  bumpmap:
+    convertToNormalMap: 0
+    externalNormalMap: 0
+    heightScale: 0.25
+    normalMapFilter: 0
+  isReadable: 0
+  streamingMipmaps: 0
+  streamingMipmapsPriority: 0
+  vTOnly: 0
+  grayScaleToAlpha: 0
+  generateCubemap: 6
+  cubemapConvolution: 0
+  seamlessCubemap: 0
+  textureFormat: 1
+  maxTextureSize: 2048
+  textureSettings:
+    serializedVersion: 2
+    filterMode: 0
+    aniso: 1
+    mipBias: 0
+    wrapU: 1
+    wrapV: 1
+    wrapW: 1
+  nPOTScale: 0
+  lightmap: 0
+  compressionQuality: 50
+  spriteMode: 1
+  spriteExtrude: 1
+  spriteMeshType: 1
+  alignment: 0
+  spritePivot: {x: 0.5, y: 0.5}
+  spritePixelsToUnits: 30
+  spriteBorder: {x: 0, y: 0, z: 0, w: 0}
+  spriteGenerateFallbackPhysicsShape: 1
+  alphaUsage: 1
+  alphaIsTransparency: 1
+  spriteTessellationDetail: -1
+  textureType: 8
+  textureShape: 1
+  singleChannelComponent: 0
+  flipbookRows: 1
+  flipbookColumns: 1
+  maxTextureSizeSet: 0
+  compressionQualitySet: 0
+  textureFormatSet: 0
+  ignorePngGamma: 0
+  applyGammaDecoding: 0
+  platformSettings:
+  - serializedVersion: 3
+    buildTarget: DefaultTexturePlatform
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Standalone
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  - serializedVersion: 3
+    buildTarget: Windows Store Apps
+    maxTextureSize: 2048
+    resizeAlgorithm: 0
+    textureFormat: -1
+    textureCompression: 1
+    compressionQuality: 50
+    crunchedCompression: 0
+    allowsAlphaSplitting: 0
+    overridden: 0
+    androidETC2FallbackOverride: 0
+    forceMaximumCompressionQuality_BC6H_BC7: 0
+  spriteSheet:
+    serializedVersion: 2
+    sprites: []
+    outline: []
+    physicsShape: []
+    bones: []
+    spriteID: 5e97eb03825dee720800000000000000
+    internalID: 0
+    vertices: []
+    indices: 
+    edges: []
+    weights: []
+    secondaryTextures: []
+  spritePackingTag: 
+  pSDRemoveMatte: 0
+  pSDShowRemoveMatteOption: 0
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/ProjectSettings/TagManager.asset
+++ b/ProjectSettings/TagManager.asset
@@ -56,3 +56,6 @@ TagManager:
   - name: Knight
     uniqueID: 2967941379
     locked: 0
+  - name: Weapon
+    uniqueID: 2942850939
+    locked: 0


### PR DESCRIPTION
The ranged knight enemy sprites have been updated. Ranged attackers can now also optionally have a `ProjectileLauncher` that will rotate towards the direction of the upcoming attack while readying.

Dragon's prefab and both ranged enemies' prefabs modified.

![image](https://user-images.githubusercontent.com/50415999/161989921-fc9c4285-92a2-422f-8dd2-6344d850ee8d.png)