### PR TITLE
Level 2 kill switch

### DIFF
--- a/Assets/Scripts/Network/RoomCreator.cs
+++ b/Assets/Scripts/Network/RoomCreator.cs
@@ -36,7 +36,7 @@ public class RoomCreator : MonoBehaviourPunCallbacks
     {
         base.OnCreatedRoom();
         isCreateOngoing = false;
-        LevelSelectManager.SetLevelsCleared(1);
+        LevelSelectManager.SetLevelsCleared(0);
     }
 
     public override void OnCreateRoomFailed(short returnCode, string message) 


### PR DESCRIPTION
This will remove the ability for players to select level 2 in the level select screen.