### PR TITLE
Create script for viewing grid in editor

### DIFF
--- a/Assets/Prefabs/Level/Pathfinding.prefab
+++ b/Assets/Prefabs/Level/Pathfinding.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 6646830660512496571}
   - component: {fileID: 7964667273574457280}
   - component: {fileID: -4079278744649468255}
+  - component: {fileID: 3353630529265617265}
   m_Layer: 0
   m_Name: Pathfinding
   m_TagString: Untagged
@@ -77,3 +78,17 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: c8fb909a49e8a6944b66bea4e829e292, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
+--- !u!114 &3353630529265617265
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7295373995106864164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: f70130cd38f67c9418ed6318bceecc2d, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  nodeGrid: {fileID: 6646830660512496571}
+  drawGrid: 1

--- a/Assets/Scripts/Pathfinding/NodeGridEditorDisplay.cs
+++ b/Assets/Scripts/Pathfinding/NodeGridEditorDisplay.cs
@@ -1,0 +1,50 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Pathfinding
+{
+    /// <summary>
+    /// Displays the grid in the editor without traversal information.
+    /// </summary>
+    /// <remarks>
+    /// The main use of the display is for editing the positions of objects in the scene editor.
+    /// </remarks>
+    public class NodeGridEditorDisplay : MonoBehaviour
+    {
+        [SerializeField] private NodeGrid nodeGrid;
+        [SerializeField] private bool drawGrid;
+
+        private void OnDrawGizmos()
+        {
+            if (!drawGrid)
+            {
+                return;
+            }
+
+            // find starting node in the bottom left of the grid
+            Vector2 worldBottomLeft = nodeGrid.Center
+                + Vector2.left * nodeGrid.WorldSize.x / 2
+                + Vector2.down * nodeGrid.WorldSize.y / 2;
+
+            Gizmos.color = Color.white;
+            float nodeDiameter = nodeGrid.NodeRadius * 2f;
+            int gridSizeX = Mathf.RoundToInt(nodeGrid.WorldSize.x / nodeDiameter);
+            int gridSizeY = Mathf.RoundToInt(nodeGrid.WorldSize.y / nodeDiameter);
+
+            Vector2 worldPoint;
+            for (int x = 0; x < gridSizeX; x++)
+            {   
+                for (int y = 0; y < gridSizeY; y++)
+                {
+                    // find position of node in world space
+                    worldPoint = worldBottomLeft
+                        + Vector2.right * (x * nodeDiameter + nodeGrid.NodeRadius)
+                        + Vector2.up * (y * nodeDiameter + nodeGrid.NodeRadius);
+
+                    Gizmos.DrawWireCube(worldPoint, Vector2.one * nodeDiameter);
+                }
+            }
+        }
+    }
+}

--- a/Assets/Scripts/Pathfinding/NodeGridEditorDisplay.cs.meta
+++ b/Assets/Scripts/Pathfinding/NodeGridEditorDisplay.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: f70130cd38f67c9418ed6318bceecc2d
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 


### PR DESCRIPTION
The grid does not display any traversal information as that is stored in the scriptable object data asset. The main purpose of this script is for positioning objects in the scene view.