### PR TITLE
Space out AI actors when pathfinding

### DIFF
--- a/Assets/Prefabs/Level/Pathfinding.prefab
+++ b/Assets/Prefabs/Level/Pathfinding.prefab
@@ -12,6 +12,7 @@ GameObject:
   - component: {fileID: 6646830660512496571}
   - component: {fileID: 7964667273574457280}
   - component: {fileID: -4079278744649468255}
+  - component: {fileID: 2661391498423079531}
   - component: {fileID: 3353630529265617265}
   m_Layer: 0
   m_Name: Pathfinding
@@ -76,6 +77,18 @@ MonoBehaviour:
   m_Enabled: 1
   m_EditorHideFlags: 0
   m_Script: {fileID: 11500000, guid: c8fb909a49e8a6944b66bea4e829e292, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+--- !u!114 &2661391498423079531
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 7295373995106864164}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: d42144e868a963940b6c650f09abdc32, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
 --- !u!114 &3353630529265617265

--- a/Assets/Scripts/Pathfinding/Node.cs
+++ b/Assets/Scripts/Pathfinding/Node.cs
@@ -25,6 +25,8 @@ namespace Pathfinding
 
         public int HeapIndex { get => heapIndex; set => heapIndex = value; }
 
+        public bool IsOccupied { get; set; }
+
         public Node(Vector2 worldPos, int gridX, int gridY, bool isWalkable, float distanceFromSurfaceBelow)
         {
             WorldPos = worldPos;
@@ -65,6 +67,22 @@ namespace Pathfinding
 
             // node with lower F Cost / H Cost should have higher priority
             return -result;
+        }
+
+        public override bool Equals(object obj)
+        {
+            Node otherNode = obj as Node;
+            if (otherNode == null)
+            {
+                return false;
+            }
+
+            return GridX == otherNode.GridX && GridY == otherNode.GridY;
+        }
+
+        public override int GetHashCode()
+        {
+            return GridX.GetHashCode() ^ GridY.GetHashCode();
         }
     }
 }

--- a/Assets/Scripts/Pathfinding/NodeOccupationManager.cs
+++ b/Assets/Scripts/Pathfinding/NodeOccupationManager.cs
@@ -1,0 +1,42 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+namespace Pathfinding
+{
+    public class NodeOccupationManager : MonoBehaviour
+    {
+        private static NodeOccupationManager _instance;
+        public static NodeOccupationManager Instance { get => _instance; }
+
+        private HashSet<Node> occupiedNodes = new HashSet<Node>();
+
+        private void Awake()
+        {
+            // singleton
+            if (_instance != null && _instance != this)
+            {
+                Destroy(gameObject);
+            }
+            else
+            {
+                _instance = this;
+            }
+        }
+
+        public bool IsNodeOccupied(Node node)
+        {
+            return occupiedNodes.Contains(node);
+        }
+
+        public void MarkNodeAsOccupied(Node node)
+        {
+            occupiedNodes.Add(node);
+        }
+
+        public void MarkNodeAsUnoccupied(Node node)
+        {
+            occupiedNodes.Remove(node);
+        }
+    }
+}

--- a/Assets/Scripts/Pathfinding/NodeOccupationManager.cs
+++ b/Assets/Scripts/Pathfinding/NodeOccupationManager.cs
@@ -9,8 +9,6 @@ namespace Pathfinding
         private static NodeOccupationManager _instance;
         public static NodeOccupationManager Instance { get => _instance; }
 
-        private HashSet<Node> occupiedNodes = new HashSet<Node>();
-
         private void Awake()
         {
             // singleton
@@ -26,17 +24,17 @@ namespace Pathfinding
 
         public bool IsNodeOccupied(Node node)
         {
-            return occupiedNodes.Contains(node);
+            return node.IsOccupied;
         }
 
         public void MarkNodeAsOccupied(Node node)
         {
-            occupiedNodes.Add(node);
+            node.IsOccupied = true;
         }
 
         public void MarkNodeAsUnoccupied(Node node)
         {
-            occupiedNodes.Remove(node);
+            node.IsOccupied = false;
         }
     }
 }

--- a/Assets/Scripts/Pathfinding/NodeOccupationManager.cs.meta
+++ b/Assets/Scripts/Pathfinding/NodeOccupationManager.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: d42144e868a963940b6c650f09abdc32
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Pathfinding/Pathfinder.cs
+++ b/Assets/Scripts/Pathfinding/Pathfinder.cs
@@ -54,7 +54,7 @@ namespace Pathfinding
 
                 foreach (Node neighbour in currentNode.Neighbours)
                 {
-                    if (!neighbour.IsWalkable || closedSet.Contains(neighbour))
+                    if (!neighbour.IsWalkable || neighbour.IsOccupied || closedSet.Contains(neighbour))
                     {
                         continue;
                     }

--- a/Assets/Scripts/Pathfinding/PathfindingUnit.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingUnit.cs
@@ -39,8 +39,7 @@ public class PathfindingUnit : MonoBehaviour
 
         commonHardNeighbourFilters = new List<NodeNeighbourFilter>()
         {
-            new NodeNeighbourFilter((node, neighbour) => NodeGrid.Instance.AreNodesBelowWalkable(neighbour, unitHeightInNodes - 1)),
-            // new NodeNeighbourFilter((node, neighbour) => !NodeOccupationManager.Instance.IsNodeOccupied(neighbour))
+            new NodeNeighbourFilter((node, neighbour) => NodeGrid.Instance.AreNodesBelowWalkable(neighbour, unitHeightInNodes - 1))
         };
 
         timeOfLastPathfind = 0f;

--- a/Assets/Scripts/Pathfinding/PathfindingUnit.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingUnit.cs
@@ -40,7 +40,7 @@ public class PathfindingUnit : MonoBehaviour
         commonHardNeighbourFilters = new List<NodeNeighbourFilter>()
         {
             new NodeNeighbourFilter((node, neighbour) => NodeGrid.Instance.AreNodesBelowWalkable(neighbour, unitHeightInNodes - 1)),
-            new NodeNeighbourFilter((node, neighbour) => !NodeOccupationManager.Instance.IsNodeOccupied(neighbour))
+            // new NodeNeighbourFilter((node, neighbour) => !NodeOccupationManager.Instance.IsNodeOccupied(neighbour))
         };
 
         timeOfLastPathfind = 0f;
@@ -117,6 +117,10 @@ public class PathfindingUnit : MonoBehaviour
         while (targetNodeIndex < path.Count)
         {
             newCurrentPosNode = GetCurrentPositionAsNode();
+            if (currentPosNode == null)
+            {
+                currentPosNode = newCurrentPosNode;
+            }
             if (newCurrentPosNode != currentPosNode)
             {
                 NodeOccupationManager.Instance.MarkNodeAsUnoccupied(currentPosNode);

--- a/Assets/Scripts/Pathfinding/PathfindingUnit.cs
+++ b/Assets/Scripts/Pathfinding/PathfindingUnit.cs
@@ -26,6 +26,8 @@ public class PathfindingUnit : MonoBehaviour
     private List<Node> path;
     private int targetNodeIndex;
 
+    private Node currentPosNode;
+
     public int HeightInNodes { get => unitHeightInNodes; }
     public Pathfinder.PathfindResult LastPathfindResult { get; private set; }
     public bool HasReachedFinalPathNode { get; private set; }
@@ -37,7 +39,8 @@ public class PathfindingUnit : MonoBehaviour
 
         commonHardNeighbourFilters = new List<NodeNeighbourFilter>()
         {
-            new NodeNeighbourFilter((node, neighbour) => NodeGrid.Instance.AreNodesBelowWalkable(neighbour, unitHeightInNodes - 1))
+            new NodeNeighbourFilter((node, neighbour) => NodeGrid.Instance.AreNodesBelowWalkable(neighbour, unitHeightInNodes - 1)),
+            new NodeNeighbourFilter((node, neighbour) => !NodeOccupationManager.Instance.IsNodeOccupied(neighbour))
         };
 
         timeOfLastPathfind = 0f;
@@ -109,11 +112,19 @@ public class PathfindingUnit : MonoBehaviour
 
     private IEnumerator MoveAlongPath()
     {
-        Node currentPosNode;
+        Node newCurrentPosNode;
         targetNodeIndex = 0;
         while (targetNodeIndex < path.Count)
         {
-            currentPosNode = GetCurrentPositionAsNode();
+            newCurrentPosNode = GetCurrentPositionAsNode();
+            if (newCurrentPosNode != currentPosNode)
+            {
+                NodeOccupationManager.Instance.MarkNodeAsUnoccupied(currentPosNode);
+                currentPosNode = newCurrentPosNode;
+            }
+
+            NodeOccupationManager.Instance.MarkNodeAsOccupied(currentPosNode);
+
             if (currentPosNode == path[targetNodeIndex])
             {
                 // reached current target node; advance to next node


### PR DESCRIPTION
AI actors should no longer consciously attempt to occupy the same node when pathfinding. This is primarily useful for when multiple actors are chasing the same combat target; they will now "queue up" as a result of this new system instead of crowding and stacking on top of each other in front of the target. The stacking can still happen, but it should occur much less often and they tend to start spreading out upon moving again.