### PR TITLE
Add sound effects to projectile explosions and rune switch interaction

### DIFF
--- a/Assets/Audio/Sound FXs/Level/Projectile_explosion.mp3
+++ b/Assets/Audio/Sound FXs/Level/Projectile_explosion.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:ca4e4446a1f02fc1248826825f0a3033bf43b5ecc81ac2b0bb974bbcf87812a1
+size 21745

--- a/Assets/Audio/Sound FXs/Level/Projectile_explosion.mp3.meta
+++ b/Assets/Audio/Sound FXs/Level/Projectile_explosion.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: 6d8a2185101c8654082c433fca089605
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Audio/Sound FXs/Level/Rune_switch.mp3
+++ b/Assets/Audio/Sound FXs/Level/Rune_switch.mp3
@@ -1,0 +1,3 @@
+version https://git-lfs.github.com/spec/v1
+oid sha256:c796a96a1ddc4c8ed8460305f04e37f0c28de697618e1fd91c4a4d06d3e96867
+size 17378

--- a/Assets/Audio/Sound FXs/Level/Rune_switch.mp3.meta
+++ b/Assets/Audio/Sound FXs/Level/Rune_switch.mp3.meta
@@ -1,0 +1,22 @@
+fileFormatVersion: 2
+guid: d5f2f4bae61c94c42a69a71cfd18e9e6
+AudioImporter:
+  externalObjects: {}
+  serializedVersion: 6
+  defaultSettings:
+    loadType: 0
+    sampleRateSetting: 0
+    sampleRateOverride: 44100
+    compressionFormat: 1
+    quality: 1
+    conversionMode: 0
+  platformSettingOverrides: {}
+  forceToMono: 0
+  normalize: 1
+  preloadAudioData: 1
+  loadInBackground: 0
+  ambisonic: 0
+  3D: 1
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Prefabs/Audio/Audio Manager.prefab
+++ b/Assets/Prefabs/Audio/Audio Manager.prefab
@@ -241,7 +241,17 @@ MonoBehaviour:
     loop: 0
     libraryIndex: 37
     audioClips:
+    - {fileID: 8300000, guid: d5f2f4bae61c94c42a69a71cfd18e9e6, type: 3}
+  - defaultVolume: 1
+    loop: 0
+    libraryIndex: 38
+    audioClips:
     - {fileID: 8300000, guid: 148fbbdd4f6d3cb45b5a1794689d9d8b, type: 3}
+  - defaultVolume: 1
+    loop: 0
+    libraryIndex: 39
+    audioClips:
+    - {fileID: 8300000, guid: 6d8a2185101c8654082c433fca089605, type: 3}
   musicTracks:
   - defaultVolume: 1
     loop: 1

--- a/Assets/Prefabs/Level/Sections/004 Melee Enemies Combined.prefab
+++ b/Assets/Prefabs/Level/Sections/004 Melee Enemies Combined.prefab
@@ -2461,7 +2461,7 @@ PrefabInstance:
       objectReference: {fileID: 0}
     - target: {fileID: 5776273130528298184, guid: 8689bdd1989c7a14c910bb5ed70ba21c, type: 3}
       propertyPath: m_LocalPosition.x
-      value: 11.14
+      value: 11.08
       objectReference: {fileID: 0}
     - target: {fileID: 5776273130528298184, guid: 8689bdd1989c7a14c910bb5ed70ba21c, type: 3}
       propertyPath: m_LocalPosition.y

--- a/Assets/Prefabs/Level/Sections/011 All Enemies Combined.prefab
+++ b/Assets/Prefabs/Level/Sections/011 All Enemies Combined.prefab
@@ -159,6 +159,49 @@ MonoBehaviour:
   m_FlexibleWidth: -1
   m_FlexibleHeight: -1
   m_LayoutPriority: 1
+--- !u!1 &2119333761877015186
+GameObject:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  serializedVersion: 6
+  m_Component:
+  - component: {fileID: 3246753482026641120}
+  - component: {fileID: 1835381640673875320}
+  m_Layer: 0
+  m_Name: VictoryFx
+  m_TagString: Untagged
+  m_Icon: {fileID: 0}
+  m_NavMeshLayer: 0
+  m_StaticEditorFlags: 0
+  m_IsActive: 1
+--- !u!4 &3246753482026641120
+Transform:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2119333761877015186}
+  m_LocalRotation: {x: 0, y: 0, z: 0, w: 1}
+  m_LocalPosition: {x: 0, y: 0, z: 0}
+  m_LocalScale: {x: 1, y: 1, z: 1}
+  m_Children: []
+  m_Father: {fileID: 6991227341289546158}
+  m_RootOrder: 5
+  m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
+--- !u!114 &1835381640673875320
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 2119333761877015186}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 6ca8ec8b64384f1448c8b4832c491491, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
 --- !u!1 &3374008880600811150
 GameObject:
   m_ObjectHideFlags: 0
@@ -434,6 +477,7 @@ Transform:
   - {fileID: 7511492411189310302}
   - {fileID: 3561172804805727503}
   - {fileID: 7434842103388331148}
+  - {fileID: 3246753482026641120}
   m_Father: {fileID: 0}
   m_RootOrder: 0
   m_LocalEulerAnglesHint: {x: 0, y: 0, z: 0}
@@ -457,6 +501,18 @@ MonoBehaviour:
         m_TargetAssemblyTypeName: UnityEngine.GameObject, UnityEngine
         m_MethodName: SetActive
         m_Mode: 6
+        m_Arguments:
+          m_ObjectArgument: {fileID: 0}
+          m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
+          m_IntArgument: 0
+          m_FloatArgument: 0
+          m_StringArgument: 
+          m_BoolArgument: 1
+        m_CallState: 2
+      - m_Target: {fileID: 1835381640673875320}
+        m_TargetAssemblyTypeName: VictoryFx, Assembly-CSharp
+        m_MethodName: Play
+        m_Mode: 1
         m_Arguments:
           m_ObjectArgument: {fileID: 0}
           m_ObjectArgumentAssemblyTypeName: UnityEngine.Object, UnityEngine
@@ -1015,6 +1071,11 @@ PrefabInstance:
       objectReference: {fileID: 0}
     m_RemovedComponents: []
   m_SourcePrefab: {fileID: 100100000, guid: 7b467fda5f2423b4f8fa4f966c2f9709, type: 3}
+--- !u!4 &309686239546274887 stripped
+Transform:
+  m_CorrespondingSourceObject: {fileID: 6112228502011077704, guid: 7b467fda5f2423b4f8fa4f966c2f9709, type: 3}
+  m_PrefabInstance: {fileID: 5809298883407777807}
+  m_PrefabAsset: {fileID: 0}
 --- !u!114 &9089967800366048834 stripped
 MonoBehaviour:
   m_CorrespondingSourceObject: {fileID: 3366663939283138125, guid: 7b467fda5f2423b4f8fa4f966c2f9709, type: 3}
@@ -1026,11 +1087,6 @@ MonoBehaviour:
   m_Script: {fileID: 11500000, guid: 6b75be019e41b1c45992bd1fd031b9c4, type: 3}
   m_Name: 
   m_EditorClassIdentifier: 
---- !u!4 &309686239546274887 stripped
-Transform:
-  m_CorrespondingSourceObject: {fileID: 6112228502011077704, guid: 7b467fda5f2423b4f8fa4f966c2f9709, type: 3}
-  m_PrefabInstance: {fileID: 5809298883407777807}
-  m_PrefabAsset: {fileID: 0}
 --- !u!1001 &7026423013200349763
 PrefabInstance:
   m_ObjectHideFlags: 0

--- a/Assets/Resources/Knight Enemy Ranged.prefab
+++ b/Assets/Resources/Knight Enemy Ranged.prefab
@@ -476,6 +476,7 @@ GameObject:
   - component: {fileID: 4948305080866607028}
   - component: {fileID: 2369876310287700112}
   - component: {fileID: 8145762069085459480}
+  - component: {fileID: 5104341060262041882}
   - component: {fileID: 8024515209172871131}
   - component: {fileID: 4901196210689690255}
   - component: {fileID: 2315394145704112158}
@@ -575,7 +576,7 @@ MonoBehaviour:
   visibility: {fileID: 8145762069085459480}
   hurtRevealDuration: 0.6
   movement: {fileID: 2080431000792514480}
-  projectileLauncherVisibility: {fileID: 8145762069085459480}
+  projectileLauncherVisibility: {fileID: 5104341060262041882}
 --- !u!114 &2080431000792514480
 MonoBehaviour:
   m_ObjectHideFlags: 0
@@ -744,6 +745,19 @@ MonoBehaviour:
   m_Name: 
   m_EditorClassIdentifier: 
   spriteRenderer: {fileID: 4826769299319132632}
+--- !u!114 &5104341060262041882
+MonoBehaviour:
+  m_ObjectHideFlags: 0
+  m_CorrespondingSourceObject: {fileID: 0}
+  m_PrefabInstance: {fileID: 0}
+  m_PrefabAsset: {fileID: 0}
+  m_GameObject: {fileID: 4861795074019271563}
+  m_Enabled: 1
+  m_EditorHideFlags: 0
+  m_Script: {fileID: 11500000, guid: 871c65cdc75e72345ba7ab47a3c13620, type: 3}
+  m_Name: 
+  m_EditorClassIdentifier: 
+  spriteRenderer: {fileID: 1119147474727389363}
 --- !u!114 &8024515209172871131
 MonoBehaviour:
   m_ObjectHideFlags: 0

--- a/Assets/Scripts/Actor Components/RangedProjectile.cs
+++ b/Assets/Scripts/Actor Components/RangedProjectile.cs
@@ -103,6 +103,7 @@ public class RangedProjectile : MonoBehaviour
         if (spawnHitEffect)
         {
             Instantiate(hitEffectPrefab, transform.position, Quaternion.identity);
+            AudioManager.Instance.PlaySoundFx(SoundFx.LibraryIndex.PROJECTILE_EXPLOSION);
         }
 
         Destroy(gameObject);

--- a/Assets/Scripts/Audio/SoundFx.cs
+++ b/Assets/Scripts/Audio/SoundFx.cs
@@ -42,7 +42,9 @@ public class SoundFx : Sound
         INSUFFICIENT_RESOURCE,
         GATE_OPENING,
         GATE_FULLY_OPEN,
-        WALL_DESTROY
+        RUNE_SWITCH,
+        WALL_DESTROY,
+        PROJECTILE_EXPLOSION
     }
 
     [Space(10)]

--- a/Assets/Scripts/Audio/VictoryFx.cs
+++ b/Assets/Scripts/Audio/VictoryFx.cs
@@ -1,0 +1,11 @@
+using System.Collections;
+using System.Collections.Generic;
+using UnityEngine;
+
+public class VictoryFx : MonoBehaviour
+{
+    public void Play()
+    {
+        AudioManager.Instance.PlaySoundFx(SoundFx.LibraryIndex.LEVEL_VICTORY);
+    }
+}

--- a/Assets/Scripts/Audio/VictoryFx.cs.meta
+++ b/Assets/Scripts/Audio/VictoryFx.cs.meta
@@ -1,0 +1,11 @@
+fileFormatVersion: 2
+guid: 6ca8ec8b64384f1448c8b4832c491491
+MonoImporter:
+  externalObjects: {}
+  serializedVersion: 2
+  defaultReferences: []
+  executionOrder: 0
+  icon: {instanceID: 0}
+  userData: 
+  assetBundleName: 
+  assetBundleVariant: 

--- a/Assets/Scripts/Interactables/RuneInteractable.cs
+++ b/Assets/Scripts/Interactables/RuneInteractable.cs
@@ -33,6 +33,7 @@ public class RuneInteractable : Interactable
         currentRuneIndex = (currentRuneIndex + 1) % runeCount;
         currentRune.sprite = puzzleManager.knightRuneSprites[currentRuneIndex];
         RuneUpdateEvent.Invoke();
+        AudioManagerSynced.Instance.PlaySoundFx(SoundFx.LibraryIndex.RUNE_SWITCH);
         endInteractionCallback();
     }
 


### PR DESCRIPTION
Let's:
* Add a sound effect when projectiles hit a target and explode.
* Add a sound effect when the Knight switches the runes on the puzzle.
* Add a sound effect when players win the level.
* (Re)Fix a bug with the Ranged Knight Enemy's arms being visible to the Knight. (I'm not sure when this fix was reversed)